### PR TITLE
SR picker refactoring

### DIFF
--- a/XenAdmin/Commands/StartVMCommand.cs
+++ b/XenAdmin/Commands/StartVMCommand.cs
@@ -84,7 +84,7 @@ namespace XenAdmin.Commands
                         SR sr = null;
                         if (vdi != null)
                             sr = vm.Connection.Resolve<SR>(vdi.SR);
-                        if (vdi == null || sr.IsBroken(true) || sr.IsDetached())
+                        if (vdi == null || sr.IsBroken() || sr.IsDetached())
                         {
                             if (!brokenCDs.ContainsKey(vm))
                             {

--- a/XenAdmin/Controls/SrPicker.cs
+++ b/XenAdmin/Controls/SrPicker.cs
@@ -194,13 +194,13 @@ namespace XenAdmin.Controls
             _ = SelectSR(selectedSr) || SelectDefaultSR() || SelectAnySR();
         }
 
-        public void UpdateDiskSize(long diskSize)
+        public void UpdateDisks(params VDI[] vdi)
         {
             Program.AssertOnEventThread();
             try
             {
                 foreach (SrPickerItem node in Items)
-                    node.UpdateDiskSize(diskSize);
+                    node.UpdateDisks(vdi);
             }
             finally
             {

--- a/XenAdmin/Controls/SrPickerItem.cs
+++ b/XenAdmin/Controls/SrPickerItem.cs
@@ -54,7 +54,7 @@ namespace XenAdmin.Controls
             }
         }
 
-        protected override bool UnsupportedSR => false;
+        protected override bool SupportsCurrentOperation => true;
     }
 
 
@@ -259,7 +259,7 @@ namespace XenAdmin.Controls
             Update();
         }
 
-        protected virtual bool UnsupportedSR => TheSR.HBALunPerVDI();
+        protected virtual bool SupportsCurrentOperation => !TheSR.HBALunPerVDI();
 
         protected abstract bool CanBeEnabled { get; }
 
@@ -274,7 +274,7 @@ namespace XenAdmin.Controls
             Text = TheSR.Name();
             Image = Images.GetImage16For(TheSR);
 
-            if (UnsupportedSR || !TheSR.SupportsVdiCreate() ||
+            if (!SupportsCurrentOperation || !TheSR.SupportsVdiCreate() ||
                 !TheSR.Show(Properties.Settings.Default.ShowHiddenVMs))
             {
                 Show = false;

--- a/XenAdmin/Controls/SrPickerItem.cs
+++ b/XenAdmin/Controls/SrPickerItem.cs
@@ -37,27 +37,6 @@ using XenAPI;
 
 namespace XenAdmin.Controls
 {
-    public class SrPickerLunPerVDIItem : SrPickerVmItem
-    {
-        public SrPickerLunPerVDIItem(SR sr, Host aff, VDI[] vdis)
-            : base(sr, aff, vdis)
-        {
-        }
-
-        protected override bool CanBeEnabled
-        {
-            get
-            {
-                if(TheSR.HBALunPerVDI())
-                    return !TheSR.IsBroken(false) && TheSR.CanBeSeenFrom(Affinity);
-                return base.CanBeEnabled;
-            }
-        }
-
-        protected override bool SupportsCurrentOperation => true;
-    }
-
-
     public class SrPickerMigrateItem : SrPickerItem
     {
         public SrPickerMigrateItem(SR sr, Host aff, VDI[] vdis)
@@ -236,6 +215,28 @@ namespace XenAdmin.Controls
                 return base.DisabledReason;
             }
         }
+    }
+
+
+    public class SrPickerLunPerVDIItem : SrPickerVmItem
+    {
+        public SrPickerLunPerVDIItem(SR sr, Host aff, VDI[] vdis)
+            : base(sr, aff, vdis)
+        {
+        }
+
+        protected override bool CanBeEnabled
+        {
+            get
+            {
+                if (TheSR.HBALunPerVDI())
+                    return !TheSR.IsBroken(false) && TheSR.CanBeSeenFrom(Affinity);
+                
+                return base.CanBeEnabled;
+            }
+        }
+
+        protected override bool SupportsCurrentOperation => true;
     }
 
 

--- a/XenAdmin/Controls/SrPickerItem.cs
+++ b/XenAdmin/Controls/SrPickerItem.cs
@@ -242,7 +242,7 @@ namespace XenAdmin.Controls
     public abstract class SrPickerItem : CustomTreeNode, IComparable<SrPickerItem>
     {
         public SR TheSR { get; }
-        public bool Show { get; private set; }
+        public bool Show { get; private set; } = true;
         protected readonly Host Affinity;
         protected long DiskSize { get; private set; }
         protected long DiskPhysicalUtilization { get; private set; }
@@ -263,11 +263,6 @@ namespace XenAdmin.Controls
 
         protected abstract bool CanBeEnabled { get; }
 
-        protected virtual void SetImage()
-        {
-            Image = Images.GetImage16For(TheSR);
-        }
-
         public void UpdateDiskSize(long diskSize)
         {
             DiskSize = diskSize;
@@ -277,24 +272,25 @@ namespace XenAdmin.Controls
         private void Update()
         {
             Text = TheSR.Name();
-            SetImage();
+            Image = Images.GetImage16For(TheSR);
 
             if (UnsupportedSR || !TheSR.SupportsVdiCreate() ||
                 !TheSR.Show(Properties.Settings.Default.ShowHiddenVMs))
+            {
+                Show = false;
                 return;
+            }
 
             if (CanBeEnabled)
             {
                 Description = string.Format(Messages.SRPICKER_DISK_FREE, Util.DiskSizeString(TheSR.FreeSpace(), 2),
                     Util.DiskSizeString(TheSR.physical_size, 2));
                 Enabled = true;
-                Show = true;
             }
             else
             {
                 Description = DisabledReason;
                 Enabled = false;
-                Show = true;
             }
         }
 

--- a/XenAdmin/Controls/SrPickerItem.cs
+++ b/XenAdmin/Controls/SrPickerItem.cs
@@ -133,7 +133,7 @@ namespace XenAdmin.Controls
                        (!TheSR.IsLocalSR() || existingVDIs.All(v => HomeHostCanSeeTargetSr(v, TheSR))) &&
                        TheSR.SupportsVdiCreate() &&
                        !TheSR.IsDetached() && 
-                       TheSR.VdiCreationCanProceed(DiskSize, DiskPhysicalUtilization) &&
+                       TheSR.CanFitDisks(DiskSize, DiskPhysicalUtilization) &&
                        TheSR.SupportsStorageMigration();
             }
         }
@@ -149,7 +149,7 @@ namespace XenAdmin.Controls
 
         protected override bool CanBeEnabled =>
             !TheSR.IsDetached() && TheSR.SupportsVdiCreate() &&
-            TheSR.VdiCreationCanProceed(DiskSize, DiskPhysicalUtilization);
+            TheSR.CanFitDisks(DiskSize, DiskPhysicalUtilization);
 
         protected override string DisabledReason
         {   
@@ -173,7 +173,7 @@ namespace XenAdmin.Controls
 
         protected override bool CanBeEnabled =>
             !TheSR.IsDetached() && !ExistingVDILocation() &&
-            TheSR.SupportsVdiCreate() && TheSR.VdiCreationCanProceed(DiskSize, DiskPhysicalUtilization);
+            TheSR.SupportsVdiCreate() && TheSR.CanFitDisks(DiskSize, DiskPhysicalUtilization);
 
         protected override string DisabledReason
         {   
@@ -197,7 +197,7 @@ namespace XenAdmin.Controls
         }
 
         protected override bool CanBeEnabled =>
-            TheSR.SupportsVdiCreate() && !TheSR.IsDetached() && TheSR.VdiCreationCanProceed(DiskSize, DiskPhysicalUtilization);
+            TheSR.SupportsVdiCreate() && !TheSR.IsDetached() && TheSR.CanFitDisks(DiskSize, DiskPhysicalUtilization);
 
         protected override string DisabledReason
         {
@@ -221,7 +221,7 @@ namespace XenAdmin.Controls
         protected override bool CanBeEnabled =>
             TheSR.CanBeSeenFrom(Affinity) &&
             TheSR.SupportsVdiCreate() && !TheSR.IsBroken(false) && !TheSR.IsFull() &&
-            TheSR.VdiCreationCanProceed(DiskSize, DiskPhysicalUtilization);
+            TheSR.CanFitDisks(DiskSize, DiskPhysicalUtilization);
 
         protected override string DisabledReason
         {

--- a/XenAdmin/Dialogs/NewDiskDialog.cs
+++ b/XenAdmin/Dialogs/NewDiskDialog.cs
@@ -238,16 +238,17 @@ namespace XenAdmin.Dialogs
 
         public VDI NewDisk()
         {
-            VDI vdi = new VDI();
-            vdi.Connection = connection;
-            vdi.read_only = DiskTemplate != null ? DiskTemplate.read_only : false;
-            vdi.SR = new XenAPI.XenRef<XenAPI.SR>(SrListBox.SR);
-
-            vdi.virtual_size = diskSpinner1.SelectedSize;
-            vdi.name_label = NameTextBox.Text;
-            vdi.name_description = DescriptionTextBox.Text;
-            vdi.sharable = DiskTemplate != null ? DiskTemplate.sharable : false;
-            vdi.type = DiskTemplate != null ? DiskTemplate.type : vdi_type.user;
+            VDI vdi = new VDI
+            {
+                Connection = connection,
+                read_only = DiskTemplate?.read_only ?? false,
+                SR = SrListBox.SR == null ? new XenRef<SR>(Helper.NullOpaqueRef) : new XenRef<SR>(SrListBox.SR),
+                virtual_size = diskSpinner1.SelectedSize,
+                name_label = NameTextBox.Text,
+                name_description = DescriptionTextBox.Text,
+                sharable = DiskTemplate?.sharable ?? false,
+                type = DiskTemplate?.type ?? vdi_type.user
+            };
             vdi.SetVmHint(TheVM != null ? TheVM.uuid : "");
             return vdi;
         }
@@ -282,7 +283,7 @@ namespace XenAdmin.Dialogs
             // Ordering is important here, we want to show the most relevant message
             // The error should be shown only for size errors
 
-            SrListBox.UpdateDiskSize(diskSpinner1.SelectedSize);
+            SrListBox.UpdateDisks(NewDisk());
 
             if (!diskSpinner1.IsSizeValid)
             {

--- a/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Storage.cs
@@ -203,7 +203,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             var sb = new StringBuilder();
 
             var suggestedSrVisible = suggestedSr != null && suggestedSr.CanBeSeenFrom(affinity);
-            var suggestedSrHasSpace = suggestedSr != null && suggestedSr.VdiCreationCanProceed(diskSize);
+            var suggestedSrHasSpace = suggestedSr != null && suggestedSr.CanFitDisks(diskSize);
 
             if (suggestedSrVisible && suggestedSrHasSpace)
                 return suggestedSr;
@@ -218,7 +218,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
             SR defaultSr = connection.Resolve(Helpers.GetPoolOfOne(connection).default_SR);
             var defaultSrVisible = defaultSr != null && defaultSr.CanBeSeenFrom(affinity);
-            var defaultSrHasSpace = defaultSr != null && defaultSr.VdiCreationCanProceed(diskSize);
+            var defaultSrHasSpace = defaultSr != null && defaultSr.CanFitDisks(diskSize);
 
             if (defaultSrVisible && defaultSrHasSpace)
             {
@@ -242,7 +242,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             foreach (SR sr in connection.Cache.SRs)
             {
                 if (sr.SupportsVdiCreate() && !sr.IsBroken(false) && !sr.IsFull() &&
-                    sr.CanBeSeenFrom(affinity) && sr.VdiCreationCanProceed(diskSize))
+                    sr.CanBeSeenFrom(affinity) && sr.CanFitDisks(diskSize))
                 {
                     if (suggestedSr != null || defaultSr != null)
                     {
@@ -299,14 +299,14 @@ namespace XenAdmin.Wizards.NewVMWizard
                         SR target = Connection.Resolve(row.Disk.SR);
 
                         if (_fullCopySR == null && row.SourceSR.Equals(target) &&
-                            target.VdiCreationCanProceed(fullCopySize))
+                            target.CanFitDisks(fullCopySize))
                             _fullCopySR = target;
 
                         if (!targetSRs.Contains(target))
                             targetSRs.Add(target);
                     }
 
-                    if (targetSRs.Count == 1 && targetSRs[0].VdiCreationCanProceed(fullCopySize))
+                    if (targetSRs.Count == 1 && targetSRs[0].CanFitDisks(fullCopySize))
                         _fullCopySR = targetSRs[0];
                 }
 
@@ -363,7 +363,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                     Util.DiskSizeString(sr.FreeSpace()),
                     Util.DiskSizeString(totalDiskSize[sr.opaque_ref]));
 
-                if (!sr.VdiCreationCanProceed(totalDiskInitialAllocation[sr.opaque_ref]))
+                if (!sr.CanFitDisks(totalDiskInitialAllocation[sr.opaque_ref]))
                     item.UpdateStatus(Images.StaticImages._000_error_h32bit_16, toolTip);
                 else if (sr.FreeSpace() < totalDiskInitialAllocation[sr.opaque_ref])
                     item.UpdateStatus(Images.StaticImages._000_Alert2_h32bit_16, toolTip);

--- a/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizard.cs
+++ b/XenAdmin/Wizards/RollingUpgradeWizard/RollingUpgradeWizard.cs
@@ -75,7 +75,7 @@ namespace XenAdmin.Wizards.RollingUpgradeWizard
         protected override void FinishWizard()
         {
             var brokenSRs = RollingUpgradeWizardSelectPool.SelectedCoordinators
-                .Any(coordinator => coordinator != null && coordinator.Connection.Cache.SRs.Any(sr => sr.IsBroken(true)));
+                .Any(coordinator => coordinator != null && coordinator.Connection.Cache.SRs.Any(sr => sr.IsBroken()));
             if(brokenSRs)
             {
                 using (var dlg = new WarningDialog(Messages.BROKEN_SRS_AFTER_UPGRADE))

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -19,7 +19,7 @@ namespace XenAdmin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Messages {
@@ -35194,6 +35194,15 @@ namespace XenAdmin {
         public static string SR_DETACHED {
             get {
                 return ResourceManager.GetString("SR_DETACHED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The SR is currently unplugged from {0}.
+        /// </summary>
+        public static string SR_DETACHED_FROM_HOST {
+            get {
+                return ResourceManager.GetString("SR_DETACHED_FROM_HOST", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -12193,6 +12193,9 @@ Reverting to this snapshot will revert the VM back to the point in time that the
   <data name="SR_DETACHED" xml:space="preserve">
     <value>The SR is currently detached.</value>
   </data>
+  <data name="SR_DETACHED_FROM_HOST" xml:space="preserve">
+    <value>The SR is currently unplugged from {0}</value>
+  </data>
   <data name="SR_DISK_SPACE_ALLOCATION" xml:space="preserve">
     <value>Initial allocation: {0}
 Incremental allocation: {1}</value>

--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -504,7 +504,7 @@ namespace XenAPI
         /// <param name="vdiSize">The size of the disk to check</param>
         /// <param name="vdiPhysicalUtilization">The physical_utilization value of the VDI(s) to check</param>
         /// <returns>true if the VDIs will fit in the SR</returns>
-        public virtual bool VdiCreationCanProceed(long vdiSize, long? vdiPhysicalUtilization = null)
+        public virtual bool CanFitDisks(long vdiSize, long? vdiPhysicalUtilization = null)
         {
             var sm = GetSM();
 

--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -69,7 +69,9 @@ namespace XenAPI
             return Name();
         }
 
-        /// <returns>A friendly name for the SR.</returns>
+        /// <summary>
+        /// A friendly name for the SR.
+        /// </summary>
         public override string Name()
         {
             return I18N("name_label", name_label, true);
@@ -96,7 +98,9 @@ namespace XenAPI
             return I18N("name_label", name_label, false);
         }
 
-        /// <returns>A friendly description for the SR.</returns>
+        /// <summary>
+        /// A friendly description for the SR.
+        /// </summary>
         public override string Description()
         {
             return I18N("name_description", name_description, true);
@@ -192,8 +196,10 @@ namespace XenAPI
             }
         }
 
-        /// <returns>The name of the host to which this SR is attached, or null if the storage is shared
-        /// or unattached.</returns>
+        /// <summary>
+        /// Gets the name of the host to which this SR is attached, or null if the storage is shared
+        /// or unattached.
+        /// </summary>
         private string GetHostName()
         {
             if (Connection == null)
@@ -202,8 +208,9 @@ namespace XenAPI
             return host == null ? null : host.Name();
         }
 
-
-        /// <returns>The host to which the given SR belongs, or null if the SR is shared or completely disconnected.</returns>
+        /// <summary>
+        /// Gets the host to which the given SR belongs, or null if the SR is shared or completely disconnected.
+        /// </summary>
         public Host GetStorageHost()
         {
             if (shared || PBDs.Count != 1)
@@ -260,23 +267,6 @@ namespace XenAPI
         }
 
         /// <summary>
-        /// Internal helper function. True if all the PBDs for this SR are currently_attached.
-        /// </summary>
-        /// <returns></returns>
-        private bool AllPBDsAttached()
-        {
-            return Connection.ResolveAll(this.PBDs).All(pbd => pbd.currently_attached);
-        }
-
-        /// <summary>
-        /// Internal helper function. True if any of the PBDs for this SR is currently_attached.
-        /// </summary>
-        private bool AnyPBDAttached()
-        {
-            return Connection.ResolveAll(this.PBDs).Any(pbd => pbd.currently_attached);
-        }
-
-        /// <summary>
         /// Returns true if there are any Running or Suspended VMs attached to VDIs on this SR.
         /// </summary>
         public bool HasRunningVMs()
@@ -323,9 +313,7 @@ namespace XenAPI
         public virtual bool CanBeSeenFrom(Host host)
         {
             if (host == null)
-            {
-                return shared && Connection != null && !IsBroken(false) && AnyPBDAttached();
-            }
+                return shared && !IsBroken();
 
             foreach (PBD pbd in host.Connection.ResolveAll(PBDs))
                 if (pbd.currently_attached && pbd.host.opaque_ref == host.opaque_ref)
@@ -357,10 +345,19 @@ namespace XenAPI
             return physical_size - physical_utilisation;
         }
 
+        /// <summary>
+        /// SR is detached when it has no PBDs or when all its PBDs are unplugged
+        /// </summary>
         public bool IsDetached()
         {
-            // SR is detached when it has no PBDs or when all its PBDs are unplugged
-            return !HasPBDs() || !AnyPBDAttached();
+            foreach (var pbdRef in PBDs)
+            {
+                var pbd = Connection.Resolve(pbdRef);
+                if (pbd != null && pbd.currently_attached)
+                    return false;
+            }
+
+            return true;
         }
 
         public bool HasPBDs()
@@ -402,40 +399,38 @@ namespace XenAPI
         }
 
         /// <summary>
-        /// The SR is broken when it has the wrong number of PBDs, or (optionally) not all the PBDs are attached.
+        /// The SR is broken when it has the wrong number of PBDs, or (optionally) not
+        /// all the PBDs are attached. For standalone host or non-shared SR there should
+        /// be exactly one PBD, otherwise a PBD for each host.
         /// </summary>
         /// <param name="checkAttached">Whether to check that all the PBDs are attached</param>
-        /// <returns></returns>
-        public virtual bool IsBroken(bool checkAttached)
+        public virtual bool IsBroken(bool checkAttached = true)
         {
-            if (PBDs == null || PBDs.Count == 0 ||
-                checkAttached && !AllPBDsAttached())
-            {
+            if (PBDs.Count == 0)
                 return true;
-            }
-            Pool pool = Helpers.GetPoolOfOne(Connection);
-            if (pool == null || !shared)
+
+            if (Helpers.GetPoolOfOne(Connection) == null || !shared)
             {
                 if (PBDs.Count != 1)
-                {
-                    // There should be exactly one PBD, since this is a non-shared SR
                     return true;
-                }
             }
             else
             {
                 if (PBDs.Count != Connection.Cache.HostCount)
-                {
-                    // There isn't a PBD for each host
                     return true;
+            }
+
+            if (checkAttached)
+            {
+                foreach (var pbdRef in PBDs)
+                {
+                    var pbd = Connection?.Resolve(pbdRef);
+                    if (pbd == null || !pbd.currently_attached)
+                        return true;
                 }
             }
-            return false;
-        }
 
-        public bool IsBroken()
-        {
-            return IsBroken(true);
+            return false;
         }
 
         public static bool IsDefaultSr(SR sr)
@@ -920,23 +915,6 @@ namespace XenAPI
                 Util.DiskSizeString(physical_utilisation),
                 Util.DiskSizeString(physical_size),
                 Util.DiskSizeString(virtual_allocation));
-        }
-
-        /// <summary>
-        /// A friendly string indicating whether the sr is detached/broken/multipath failing/needs upgrade/ok
-        /// </summary>
-        public String StatusString()
-        {
-            if (!HasPBDs())
-                return Messages.DETACHED;
-
-            if (IsDetached() || IsBroken())
-                return Messages.GENERAL_SR_STATE_BROKEN;
-
-            if (!MultipathAOK())
-                return Messages.GENERAL_MULTIPATH_FAILURE;
-
-            return Messages.GENERAL_STATE_OK;
         }
 
         /// <summary>


### PR DESCRIPTION
This removes some of the complexity and repetition from the SrPicketItem child classes and places all the size checking logic in the SR.CanFitDisks extension method. There is some complexity added in the abstract SrPickerItem class - I have some extra commits to address this, but I'll put them in a separate PR with another couple of fixes for master because this one will grow too long. The changes are risky and I hope I haven't broken anything, but I think they are worth making as the SrPickerItems should be easier to understand and work on now.