### PR TITLE
Additional changes

### DIFF
--- a/XenAdmin/Controls/Ballooning/MemorySpinner.cs
+++ b/XenAdmin/Controls/Ballooning/MemorySpinner.cs
@@ -47,20 +47,12 @@ namespace XenAdmin.Controls.Ballooning
             previousUnitsValue = Messages.VAL_GIGB;
         }
 
-        public void Initialize(double amount, double static_max, string units = null)
+        public void Initialize(double amount, double static_max)
         {
             amount = Util.CorrectRoundingErrors(amount);
 
+            Units = static_max <= Util.BINARY_GIGA ? Messages.VAL_MEGB : Messages.VAL_GIGB;
 
-            if (units != Messages.VAL_MEGB && units != Messages.VAL_GIGB)
-            {
-                Units = Units = static_max <= Util.BINARY_GIGA ? Messages.VAL_MEGB : Messages.VAL_GIGB;
-            }
-            else
-            {
-                Units = units;
-            }
-            
             ChangeSpinnerSettings();
             previousUnitsValue = Units;
             Initialize(amount, RoundingBehaviour.None);

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.Designer.cs
@@ -37,28 +37,27 @@ namespace XenAdmin.SettingsPanels
             this.warningsTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.cpuWarningPictureBox = new System.Windows.Forms.PictureBox();
             this.cpuWarningLabel = new System.Windows.Forms.Label();
-            this.memoryWarningLabel = new System.Windows.Forms.Label();
             this.topologyWarningLabel = new System.Windows.Forms.Label();
-            this.memoryPictureBox = new System.Windows.Forms.PictureBox();
             this.topologyPictureBox = new System.Windows.Forms.PictureBox();
             this.comboBoxInitialVCPUs = new System.Windows.Forms.ComboBox();
             this.labelInitialVCPUs = new System.Windows.Forms.Label();
             this.comboBoxTopology = new XenAdmin.Controls.CPUTopologyComboBox();
             this.labelTopology = new System.Windows.Forms.Label();
-            this.MemWarningLabel = new System.Windows.Forms.Label();
-            this.memorySpinner = new XenAdmin.Controls.Ballooning.MemorySpinner();
             this.panel1 = new System.Windows.Forms.Panel();
             this.transparentTrackBar1 = new XenAdmin.Controls.TransparentTrackBar();
             this.lblVCPUs = new System.Windows.Forms.Label();
-            this.lblMemory = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.comboBoxVCPUs = new System.Windows.Forms.ComboBox();
+            this.tableLayoutPanelInfo = new System.Windows.Forms.TableLayoutPanel();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.labelInfo = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             this.warningsTableLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.topologyPictureBox)).BeginInit();
             this.panel1.SuspendLayout();
+            this.tableLayoutPanelInfo.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.SuspendLayout();
             // 
             // lblSliderHighest
@@ -79,37 +78,33 @@ namespace XenAdmin.SettingsPanels
             // lblPriority
             // 
             resources.ApplyResources(this.lblPriority, "lblPriority");
-            this.tableLayoutPanel1.SetColumnSpan(this.lblPriority, 4);
+            this.tableLayoutPanel1.SetColumnSpan(this.lblPriority, 3);
             this.lblPriority.Name = "lblPriority";
             // 
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.BackColor = System.Drawing.Color.Transparent;
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.warningsTableLayoutPanel, 0, 12);
-            this.tableLayoutPanel1.Controls.Add(this.comboBoxInitialVCPUs, 1, 6);
-            this.tableLayoutPanel1.Controls.Add(this.labelInitialVCPUs, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.comboBoxTopology, 1, 4);
-            this.tableLayoutPanel1.Controls.Add(this.labelTopology, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.MemWarningLabel, 3, 10);
-            this.tableLayoutPanel1.Controls.Add(this.memorySpinner, 1, 10);
-            this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 9);
-            this.tableLayoutPanel1.Controls.Add(this.lblPriority, 0, 8);
+            this.tableLayoutPanel1.Controls.Add(this.warningsTableLayoutPanel, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.comboBoxInitialVCPUs, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(this.labelInitialVCPUs, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.comboBoxTopology, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.labelTopology, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.lblPriority, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.lblVCPUs, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.lblMemory, 0, 10);
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxVCPUs, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanelInfo, 0, 1);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             // 
             // warningsTableLayoutPanel
             // 
             resources.ApplyResources(this.warningsTableLayoutPanel, "warningsTableLayoutPanel");
-            this.tableLayoutPanel1.SetColumnSpan(this.warningsTableLayoutPanel, 4);
+            this.tableLayoutPanel1.SetColumnSpan(this.warningsTableLayoutPanel, 3);
             this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningPictureBox, 0, 0);
             this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningLabel, 1, 0);
-            this.warningsTableLayoutPanel.Controls.Add(this.memoryWarningLabel, 1, 1);
             this.warningsTableLayoutPanel.Controls.Add(this.topologyWarningLabel, 0, 2);
-            this.warningsTableLayoutPanel.Controls.Add(this.memoryPictureBox, 0, 1);
             this.warningsTableLayoutPanel.Controls.Add(this.topologyPictureBox, 0, 2);
             this.warningsTableLayoutPanel.Name = "warningsTableLayoutPanel";
             // 
@@ -125,22 +120,10 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.cpuWarningLabel, "cpuWarningLabel");
             this.cpuWarningLabel.Name = "cpuWarningLabel";
             // 
-            // memoryWarningLabel
-            // 
-            resources.ApplyResources(this.memoryWarningLabel, "memoryWarningLabel");
-            this.memoryWarningLabel.Name = "memoryWarningLabel";
-            // 
             // topologyWarningLabel
             // 
             resources.ApplyResources(this.topologyWarningLabel, "topologyWarningLabel");
             this.topologyWarningLabel.Name = "topologyWarningLabel";
-            // 
-            // memoryPictureBox
-            // 
-            this.memoryPictureBox.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
-            resources.ApplyResources(this.memoryPictureBox, "memoryPictureBox");
-            this.memoryPictureBox.Name = "memoryPictureBox";
-            this.memoryPictureBox.TabStop = false;
             // 
             // topologyPictureBox
             // 
@@ -164,7 +147,7 @@ namespace XenAdmin.SettingsPanels
             // 
             // comboBoxTopology
             // 
-            this.tableLayoutPanel1.SetColumnSpan(this.comboBoxTopology, 3);
+            this.tableLayoutPanel1.SetColumnSpan(this.comboBoxTopology, 2);
             this.comboBoxTopology.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             resources.ApplyResources(this.comboBoxTopology, "comboBoxTopology");
             this.comboBoxTopology.FormattingEnabled = true;
@@ -176,25 +159,10 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.labelTopology, "labelTopology");
             this.labelTopology.Name = "labelTopology";
             // 
-            // MemWarningLabel
-            // 
-            resources.ApplyResources(this.MemWarningLabel, "MemWarningLabel");
-            this.MemWarningLabel.ForeColor = System.Drawing.Color.Red;
-            this.MemWarningLabel.Name = "MemWarningLabel";
-            this.tableLayoutPanel1.SetRowSpan(this.MemWarningLabel, 2);
-            // 
-            // memorySpinner
-            // 
-            resources.ApplyResources(this.memorySpinner, "memorySpinner");
-            this.tableLayoutPanel1.SetColumnSpan(this.memorySpinner, 2);
-            this.memorySpinner.Increment = 0.1D;
-            this.memorySpinner.Name = "memorySpinner";
-            this.memorySpinner.SpinnerValueChanged += new System.EventHandler(this.memorySpinner_SpinnerValueChanged);
-            // 
             // panel1
             // 
             resources.ApplyResources(this.panel1, "panel1");
-            this.tableLayoutPanel1.SetColumnSpan(this.panel1, 4);
+            this.tableLayoutPanel1.SetColumnSpan(this.panel1, 3);
             this.panel1.Controls.Add(this.lblSliderHighest);
             this.panel1.Controls.Add(this.lblSliderNormal);
             this.panel1.Controls.Add(this.lblSliderLowest);
@@ -213,15 +181,10 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.lblVCPUs, "lblVCPUs");
             this.lblVCPUs.Name = "lblVCPUs";
             // 
-            // lblMemory
-            // 
-            resources.ApplyResources(this.lblMemory, "lblMemory");
-            this.lblMemory.Name = "lblMemory";
-            // 
             // label1
             // 
             resources.ApplyResources(this.label1, "label1");
-            this.tableLayoutPanel1.SetColumnSpan(this.label1, 4);
+            this.tableLayoutPanel1.SetColumnSpan(this.label1, 3);
             this.label1.Name = "label1";
             // 
             // comboBoxVCPUs
@@ -231,6 +194,26 @@ namespace XenAdmin.SettingsPanels
             resources.ApplyResources(this.comboBoxVCPUs, "comboBoxVCPUs");
             this.comboBoxVCPUs.Name = "comboBoxVCPUs";
             this.comboBoxVCPUs.SelectedIndexChanged += new System.EventHandler(this.comboBoxVCPUs_SelectedIndexChanged);
+            // 
+            // tableLayoutPanelInfo
+            // 
+            resources.ApplyResources(this.tableLayoutPanelInfo, "tableLayoutPanelInfo");
+            this.tableLayoutPanel1.SetColumnSpan(this.tableLayoutPanelInfo, 3);
+            this.tableLayoutPanelInfo.Controls.Add(this.pictureBox1, 0, 0);
+            this.tableLayoutPanelInfo.Controls.Add(this.labelInfo, 1, 0);
+            this.tableLayoutPanelInfo.Name = "tableLayoutPanelInfo";
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Image = global::XenAdmin.Properties.Resources._000_Info3_h32bit_16;
+            resources.ApplyResources(this.pictureBox1, "pictureBox1");
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.TabStop = false;
+            // 
+            // labelInfo
+            // 
+            resources.ApplyResources(this.labelInfo, "labelInfo");
+            this.labelInfo.Name = "labelInfo";
             // 
             // CpuMemoryEditPage
             // 
@@ -246,10 +229,12 @@ namespace XenAdmin.SettingsPanels
             this.warningsTableLayoutPanel.ResumeLayout(false);
             this.warningsTableLayoutPanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.topologyPictureBox)).EndInit();
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
+            this.tableLayoutPanelInfo.ResumeLayout(false);
+            this.tableLayoutPanelInfo.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -263,9 +248,7 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.Label lblSliderLowest;
         private System.Windows.Forms.Label lblPriority;
         private System.Windows.Forms.Label lblVCPUs;
-        private System.Windows.Forms.Label lblMemory;
         private XenAdmin.Controls.TransparentTrackBar transparentTrackBar1;
-        private System.Windows.Forms.Label MemWarningLabel;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label labelTopology;
         private XenAdmin.Controls.CPUTopologyComboBox comboBoxTopology;
@@ -275,10 +258,10 @@ namespace XenAdmin.SettingsPanels
         private System.Windows.Forms.TableLayoutPanel warningsTableLayoutPanel;
         private System.Windows.Forms.PictureBox cpuWarningPictureBox;
         private System.Windows.Forms.Label cpuWarningLabel;
-        private System.Windows.Forms.Label memoryWarningLabel;
-        private System.Windows.Forms.PictureBox memoryPictureBox;
         private System.Windows.Forms.Label topologyWarningLabel;
         private System.Windows.Forms.PictureBox topologyPictureBox;
-        private Controls.Ballooning.MemorySpinner memorySpinner;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelInfo;
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Label labelInfo;
     }
 }

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.cs
@@ -32,13 +32,10 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using XenAdmin.Actions;
-using XenAdmin.Commands;
 using XenAdmin.Core;
 using XenAPI;
-using XenAdmin.Dialogs;
 
 namespace XenAdmin.SettingsPanels
 {
@@ -47,9 +44,7 @@ namespace XenAdmin.SettingsPanels
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
 
         private VM _vm;
-        private bool _showMemory; // If this VM has DMC, we don't show the memory controls on this page.
         private bool _validToSave = true;
-        private double _origMemory;
         private long _origVCpus;
         private long _origVCpusMax;
         private long _origVCpusAtStartup;
@@ -63,10 +58,6 @@ namespace XenAdmin.SettingsPanels
         // If vCPU hotplug is supported, comboBoxVCPUs represents the maximum number of vCPUs (VCPUs_max). And the initial number of vCPUs is represented in comboBoxInitialVCPUs (which is only visible in this case) 
         // If vCPU hotplug is not supported, comboBoxVCPUs represents the initial number of vCPUs (VCPUs_at_startup). In this case we will also set the VM property VCPUs_max to the same value.
         // We use the _OrigVCPUs variable to store the original value that populates this combo box (VCPUs_max if hotplug is allowed, otherwise VCPUs_at_startup)
-
-        private ChangeMemorySettingsAction _memoryAction;
-
-        private bool HasMemoryChanged => _origMemory != memorySpinner.Value;
 
         private bool HasVCpuChanged => _origVCpus != (long)comboBoxVCPUs.SelectedItem;
 
@@ -85,18 +76,13 @@ namespace XenAdmin.SettingsPanels
 
         public Image Image => Images.StaticImages._000_CPU_h32bit_16;
 
-        public string SubText =>
-            _showMemory
-                ? string.Format(Messages.CPU_AND_MEMORY_SUB, SelectedVCpusAtStartup, memorySpinner.Value / Util.BINARY_MEGA)
-                : string.Format(Messages.CPU_SUB, SelectedVCpusAtStartup);
+        public string SubText => string.Format(Messages.CPU_SUB, SelectedVCpusAtStartup);
 
         public CpuMemoryEditPage()
         {
             InitializeComponent();
-
-            Text = Messages.CPU_AND_MEMORY;
-
-            transparentTrackBar1.Scroll += new EventHandler(tbPriority_Scroll);
+            transparentTrackBar1.Scroll += tbPriority_Scroll;
+            Text = Messages.CPU;
         }
 
         private void InitializeVCpuControls()
@@ -134,48 +120,44 @@ namespace XenAdmin.SettingsPanels
             panel1.Enabled = _vm.power_state == vm_power_state.Halted;
         }
 
-        public void Repopulate()
+        private void Repopulate()
         {
             var vm = _vm;
-
-            Text = _showMemory ? Messages.CPU_AND_MEMORY : Messages.CPU;
-            if (!_showMemory)
-                lblMemory.Visible = memorySpinner.Visible = MemWarningLabel.Visible = false;
-            else if (vm.power_state != vm_power_state.Halted && vm.power_state != vm_power_state.Running)
-            {
-                memorySpinner.Enabled = false;
-            }
-
-            // Since updates come in dribs and drabs, avoid error if new max and min arrive
-            // out of sync and maximum < minimum.
-            if (vm.memory_dynamic_max >= vm.memory_dynamic_min &&
-                vm.memory_static_max >= vm.memory_static_min)
-            {
-                var min = vm.memory_static_min;
-                var max = vm.MaxMemAllowed();
-                var value = vm.memory_static_max;
-                // Avoid setting the range to exclude the current value: CA-40041
-                if (value > max)
-                    max = value;
-                if (value < min)
-                    min = value;
-                memorySpinner.Initialize(value, max, Messages.VAL_MEGB);
-                memorySpinner.SetRange(min, max);
-                ValidateMemorySettings();
-            }
 
             _isVCpuHotplugSupported = vm.SupportsVcpuHotplug();
             _minVCpus = vm.MinVCPUs();
 
-            label1.Text = GetRubric();
+            label1.Text = Messages.VM_CPUMEMPAGE_RUBRIC;
 
-            _origMemory = memorySpinner.Value;
+            if (_isVCpuHotplugSupported)
+                label1.Text += Messages.VM_CPUMEMPAGE_RUBRIC_HOTPLUG;
+
+            if (_vm.power_state != vm_power_state.Halted)
+            {
+                if (_isVCpuHotplugSupported)
+                {
+                    labelInfo.Text = Messages.VM_CPUMEMPAGE_MAX_VCPUS_READONLY;
+
+                    if (_vm.power_state != vm_power_state.Running)
+                        labelInfo.Text += Messages.VM_CPUMEMPAGE_CURRENT_VCPUS_READONLY;
+                }
+                else
+                {
+                    labelInfo.Text = Messages.VCPU_ONLY_WHEN_HALTED;
+                }
+
+                tableLayoutPanelInfo.Visible = true;
+            }
+            else
+            {
+                tableLayoutPanelInfo.Visible = false;
+            }
+
             _origVCpusMax = vm.VCPUs_max > 0 ? vm.VCPUs_max : 1;
             _origVCpusAtStartup = vm.VCPUs_at_startup > 0 ? vm.VCPUs_at_startup : 1;
             _origVCpuWeight = _currentVCpuWeight;
             _origVCpus = _isVCpuHotplugSupported ? _origVCpusMax : _origVCpusAtStartup;
-            _prevVCpusMax =
-                _origVCpusMax; // we use variable in RefreshCurrentVCPUs for checking if VcpusAtStartup and VcpusMax were equal before VcpusMax changed
+            _prevVCpusMax = _origVCpusMax; // we use variable in RefreshCurrentVCPUs for checking if VcpusAtStartup and VcpusMax were equal before VcpusMax changed
 
             _currentVCpuWeight = Convert.ToDecimal(vm.GetVcpuWeight());
 
@@ -212,51 +194,17 @@ namespace XenAdmin.SettingsPanels
             PopulateVCpuComboBox(comboBoxInitialVCPUs, min, max, currentValue, i => true);
         }
 
-        private string GetRubric()
-        {
-            var sb = new StringBuilder();
-            sb.Append(Messages.VM_CPUMEMPAGE_RUBRIC);
-            // add hotplug text
-            if (_isVCpuHotplugSupported)
-                sb.Append(Messages.VM_CPUMEMPAGE_RUBRIC_HOTPLUG);
-            // add power state warning
-            if (_vm.power_state != vm_power_state.Halted)
-            {
-                sb.AppendLine();
-                sb.AppendLine();
-                sb.Append(_isVCpuHotplugSupported
-                    ? Messages.VM_CPUMEMPAGE_MAX_VCPUS_READONLY
-                    : Messages.VCPU_ONLY_WHEN_HALTED);
-            }
-
-            // add power state warning for Current number of vCPUs
-            if (_isVCpuHotplugSupported && _vm.power_state != vm_power_state.Halted &&
-                _vm.power_state != vm_power_state.Running)
-            {
-                sb.Append(Messages.VM_CPUMEMPAGE_CURRENT_VCPUS_READONLY);
-            }
-
-            return sb.ToString();
-        }
-
-        private void ShowMemoryWarnings(IReadOnlyCollection<string> warnings)
-        {
-            var show = warnings.Count > 0;
-            memoryWarningLabel.Text = show ? string.Join(Environment.NewLine, warnings) : null;
-            memoryPictureBox.Visible = memoryWarningLabel.Visible = show;
-        }
-
         private void ShowCpuWarnings(IReadOnlyCollection<string> warnings)
         {
             var show = warnings.Count > 0;
-            cpuWarningLabel.Text = show ? string.Join(Environment.NewLine, warnings) : null;
+            cpuWarningLabel.Text = show ? string.Join($"{Environment.NewLine}{Environment.NewLine}", warnings) : null;
             cpuWarningPictureBox.Visible = cpuWarningLabel.Visible = show;
         }
 
         private void ShowTopologyWarnings(IReadOnlyCollection<string> warnings)
         {
             var show = warnings.Count > 0;
-            topologyWarningLabel.Text = show ? string.Join(Environment.NewLine, warnings) : null;
+            topologyWarningLabel.Text = show ? string.Join($"{Environment.NewLine}{Environment.NewLine}", warnings) : null;
             topologyPictureBox.Visible = topologyWarningLabel.Visible = show;
         }
 
@@ -264,6 +212,7 @@ namespace XenAdmin.SettingsPanels
         {
             if (_vm == null || !comboBoxVCPUs.Enabled)
                 return;
+
             var homeHost = _vm.Home();
             var maxPhysicalCpus = _vm.Connection.Cache.Hosts.Select(h => h.host_CPUs.Count).Max();
             var homeHostPhysicalCpus = homeHost?.host_CPUs.Count;
@@ -282,10 +231,12 @@ namespace XenAdmin.SettingsPanels
                     warnings.Add(Messages.VM_CPUMEMPAGE_VCPU_WARNING);
                 }
             }
+
             if (comboBoxVCPUs.SelectedItem != null && SelectedVCpusMax < _minVCpus)
             {
                 warnings.Add(string.Format(Messages.VM_CPUMEMPAGE_VCPU_MIN_WARNING, _minVCpus));
             }
+
             if (comboBoxVCPUs.SelectedItem != null && SelectedVCpusMax > VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS)
             {
                 warnings.Add(string.Format(Messages.VCPUS_UNTRUSTED_VM_WARNING, VM.MAX_VCPUS_FOR_NON_TRUSTED_VMS, BrandManager.ProductBrand));
@@ -305,62 +256,13 @@ namespace XenAdmin.SettingsPanels
             if (comboBoxVCPUs.SelectedItem != null)
             {
                 var topologyWarning = VM.ValidVCPUConfiguration((long)comboBoxVCPUs.SelectedItem, comboBoxTopology.CoresPerSocket);
+
                 if (!string.IsNullOrEmpty(topologyWarning))
                 {
                     warnings.Add($"{topologyWarning}.");
                 }
             }
             ShowTopologyWarnings(warnings);
-        }
-
-        private void ValidateMemorySettings()
-        {
-            var warnings = new List<string>();
-            if (_vm != null && _showMemory)
-            {
-                if (_vm.power_state != vm_power_state.Halted && _vm.power_state != vm_power_state.Running)
-                {
-                    warnings.Add(Messages.MEM_NOT_WHEN_SUSPENDED);
-                }
-
-                var selectedAffinity =
-                    _vm.Connection.Resolve(_vm.power_state == vm_power_state.Running ? _vm.resident_on : _vm.affinity);
-                if (selectedAffinity != null)
-                {
-                    var hostMetrics = _vm.Connection.Resolve(selectedAffinity.metrics);
-                    if (hostMetrics != null && hostMetrics.memory_total < memorySpinner.Value)
-                    {
-                        warnings.Add(Messages.VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_HOST);
-                    }
-                }
-                else
-                {
-                    var hosts = _vm.Connection.Cache.Hosts;
-                    var hostHasEnoughMemory = false;
-                    foreach (var host in hosts)
-                    {
-                        if (host == null)
-                        {
-                            log.Warn($"One of the hosts cached for VM {_vm.Name()} is null. Cannot check its metrics.");
-                            continue;
-                        }
-
-                        var hostMetrics = _vm.Connection.Resolve(host.metrics);
-                        if (hostMetrics.memory_total < memorySpinner.Value)
-                        {
-                            continue;
-                        }
-                        hostHasEnoughMemory = true;
-                        break;
-                    }
-
-                    if (!hostHasEnoughMemory)
-                    {
-                        warnings.Add(Messages.VM_CPUMEMPAGE_INSUFFICIENT_MEMORY_POOL);
-                    }
-                }
-            }
-            ShowMemoryWarnings(warnings);
         }
 
         private void RefreshCurrentVCpus()
@@ -384,27 +286,6 @@ namespace XenAdmin.SettingsPanels
             }
         }
 
-        private ChangeMemorySettingsAction ConfirmAndCalculateActions(long memoryBytes)
-        {
-            if (_vm.power_state != vm_power_state.Halted)
-            {
-                var msg = _vm.SupportsBallooning() && !Helpers.FeatureForbidden(_vm, Host.RestrictDMC)
-                    ? Messages.CONFIRM_CHANGE_MEMORY_MAX_SINGULAR
-                    : Messages.CONFIRM_CHANGE_MEMORY_SINGULAR;
-
-                using (var dlg = new WarningDialog(msg,
-                           ThreeButtonDialog.ButtonYes, ThreeButtonDialog.ButtonNo))
-                {
-                    if (dlg.ShowDialog(this) != DialogResult.Yes)
-                        return null;
-                }
-            }
-
-            return new ChangeMemorySettingsAction(_vm,
-                string.Format(Messages.ACTION_CHANGE_MEMORY_SETTINGS, _vm.Name()), _vm.memory_static_min, memoryBytes, memoryBytes, memoryBytes,
-                VMOperationCommand.WarningDialogHAInvalidConfig, VMOperationCommand.StartDiagnosisForm, true);
-        }
-
         #region IEditPage
 
         public AsyncAction SaveSettings()
@@ -424,11 +305,6 @@ namespace XenAdmin.SettingsPanels
             if (HasTopologyChanged)
             {
                 _vm.SetCoresPerSocket(comboBoxTopology.CoresPerSocket);
-            }
-
-            if (HasMemoryChanged)
-            {
-                actions.Add(_memoryAction); // Calculated in ValidToSave
             }
 
             switch (actions.Count)
@@ -451,30 +327,10 @@ namespace XenAdmin.SettingsPanels
         public void SetXenObjects(IXenObject orig, IXenObject clone)
         {
             _vm = (VM)clone;
-            _showMemory = Helpers.FeatureForbidden(_vm, Host.RestrictDMC);
             Repopulate();
         }
 
-        public bool ValidToSave
-        {
-            get
-            {
-                if (!_validToSave)
-                    return false;
-
-                // Also confirm whether the user wants to save memory changes.
-                // If not, don't close the properties dialog.
-                if (HasMemoryChanged)
-                {
-                    var mem = Convert.ToInt64(memorySpinner.Value);
-                    _memoryAction = ConfirmAndCalculateActions(mem);
-                    if (_memoryAction == null)
-                        return false;
-                }
-
-                return true;
-            }
-        }
+        public bool ValidToSave => _validToSave;
 
         /** Show local validation balloon tooltips */
         public void ShowLocalValidationMessages()
@@ -493,7 +349,7 @@ namespace XenAdmin.SettingsPanels
             // not applicable
         }
 
-        public bool HasChanged => HasVCpuChanged || HasMemoryChanged || HasTopologyChanged ||
+        public bool HasChanged => HasVCpuChanged || HasTopologyChanged ||
                                   HasVCpusAtStartupChanged || HasVCpuWeightChanged;
 
         #endregion
@@ -523,10 +379,6 @@ namespace XenAdmin.SettingsPanels
             _currentVCpuWeight = Convert.ToDecimal(Math.Pow(4.0d, Convert.ToDouble(transparentTrackBar1.Value)));
             if (transparentTrackBar1.Value == transparentTrackBar1.Max)
                 _currentVCpuWeight--;
-        }
-        private void memorySpinner_SpinnerValueChanged(object sender, EventArgs e)
-        {
-            ValidateMemorySettings();
         }
 
         #endregion

--- a/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
+++ b/XenAdmin/SettingsPanels/CPUMemoryEditPage.resx
@@ -226,7 +226,7 @@
     <value>True</value>
   </data>
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>3</value>
   </data>
   <data name="warningsTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -241,16 +241,10 @@
     <value>NoControl</value>
   </data>
   <data name="cpuWarningPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 3</value>
-  </data>
-  <data name="cpuWarningPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>3, 3</value>
   </data>
   <data name="cpuWarningPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 16</value>
-  </data>
-  <data name="cpuWarningPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
+    <value>16, 16</value>
   </data>
   <data name="cpuWarningPictureBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -270,6 +264,9 @@
   <data name="&gt;&gt;cpuWarningPictureBox.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="cpuWarningLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="cpuWarningLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -277,16 +274,13 @@
     <value>NoControl</value>
   </data>
   <data name="cpuWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 3</value>
-  </data>
-  <data name="cpuWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>25, 4</value>
   </data>
   <data name="cpuWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 13</value>
   </data>
   <data name="cpuWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="cpuWarningLabel.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -303,38 +297,8 @@
   <data name="&gt;&gt;cpuWarningLabel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="memoryWarningLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="memoryWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="memoryWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 25</value>
-  </data>
-  <data name="memoryWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
-  </data>
-  <data name="memoryWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 13</value>
-  </data>
-  <data name="memoryWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="memoryWarningLabel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;memoryWarningLabel.Name" xml:space="preserve">
-    <value>memoryWarningLabel</value>
-  </data>
-  <data name="&gt;&gt;memoryWarningLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;memoryWarningLabel.Parent" xml:space="preserve">
-    <value>warningsTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;memoryWarningLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="topologyWarningLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="topologyWarningLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -343,16 +307,13 @@
     <value>NoControl</value>
   </data>
   <data name="topologyWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 47</value>
-  </data>
-  <data name="topologyWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>25, 32</value>
   </data>
   <data name="topologyWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 13</value>
   </data>
   <data name="topologyWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>2</value>
   </data>
   <data name="topologyWarningLabel.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -367,55 +328,16 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;topologyWarningLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="memoryPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="memoryPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="memoryPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
-  </data>
-  <data name="memoryPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 16</value>
-  </data>
-  <data name="memoryPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
-  </data>
-  <data name="memoryPictureBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="memoryPictureBox.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;memoryPictureBox.Name" xml:space="preserve">
-    <value>memoryPictureBox</value>
-  </data>
-  <data name="&gt;&gt;memoryPictureBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;memoryPictureBox.Parent" xml:space="preserve">
-    <value>warningsTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;memoryPictureBox.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>2</value>
   </data>
   <data name="topologyPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="topologyPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 47</value>
-  </data>
-  <data name="topologyPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>3, 31</value>
   </data>
   <data name="topologyPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 14</value>
-  </data>
-  <data name="topologyPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
+    <value>16, 16</value>
   </data>
   <data name="topologyPictureBox.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -433,25 +355,25 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;topologyPictureBox.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>3</value>
   </data>
   <data name="warningsTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
   <data name="warningsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 263</value>
+    <value>0, 255</value>
   </data>
   <data name="warningsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>0, 20, 0, 0</value>
   </data>
   <data name="warningsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="warningsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>500, 64</value>
+    <value>500, 50</value>
   </data>
   <data name="warningsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>11</value>
   </data>
   <data name="&gt;&gt;warningsTableLayoutPanel.Name" xml:space="preserve">
     <value>warningsTableLayoutPanel</value>
@@ -466,16 +388,16 @@
     <value>0</value>
   </data>
   <data name="warningsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryWarningLabel" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="topologyWarningLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="memoryPictureBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="topologyPictureBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,30,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Absolute,20,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="topologyWarningLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="topologyPictureBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,6,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="comboBoxInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 98</value>
+    <value>129, 130</value>
   </data>
   <data name="comboBoxInitialVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 21</value>
   </data>
   <data name="comboBoxInitialVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="&gt;&gt;comboBoxInitialVCPUs.Name" xml:space="preserve">
     <value>comboBoxInitialVCPUs</value>
@@ -489,32 +411,26 @@
   <data name="&gt;&gt;comboBoxInitialVCPUs.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="labelInitialVCPUs.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="labelInitialVCPUs.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="labelInitialVCPUs.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="labelInitialVCPUs.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="labelInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 98</value>
-  </data>
-  <data name="labelInitialVCPUs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>3, 134</value>
   </data>
   <data name="labelInitialVCPUs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 21</value>
+    <value>120, 13</value>
   </data>
   <data name="labelInitialVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>5</value>
   </data>
   <data name="labelInitialVCPUs.Text" xml:space="preserve">
     <value>Initial number of v&amp;CPUs:</value>
-  </data>
-  <data name="labelInitialVCPUs.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;labelInitialVCPUs.Name" xml:space="preserve">
     <value>labelInitialVCPUs</value>
@@ -532,13 +448,13 @@
     <value>Tahoma, 8pt</value>
   </data>
   <data name="comboBoxTopology.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 71</value>
+    <value>129, 103</value>
   </data>
   <data name="comboBoxTopology.Size" type="System.Drawing.Size, System.Drawing">
     <value>250, 21</value>
   </data>
   <data name="comboBoxTopology.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>4</value>
   </data>
   <data name="&gt;&gt;comboBoxTopology.Name" xml:space="preserve">
     <value>comboBoxTopology</value>
@@ -552,32 +468,26 @@
   <data name="&gt;&gt;comboBoxTopology.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="labelTopology.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
   <data name="labelTopology.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="labelTopology.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="labelTopology.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="labelTopology.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 71</value>
-  </data>
-  <data name="labelTopology.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>3, 107</value>
   </data>
   <data name="labelTopology.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 21</value>
+    <value>54, 13</value>
   </data>
   <data name="labelTopology.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>3</value>
   </data>
   <data name="labelTopology.Text" xml:space="preserve">
     <value>&amp;Topology:</value>
-  </data>
-  <data name="labelTopology.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;labelTopology.Name" xml:space="preserve">
     <value>labelTopology</value>
@@ -590,75 +500,6 @@
   </data>
   <data name="&gt;&gt;labelTopology.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="MemWarningLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="MemWarningLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="MemWarningLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="MemWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>230, 234</value>
-  </data>
-  <data name="MemWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 26</value>
-  </data>
-  <data name="MemWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="MemWarningLabel.Text" xml:space="preserve">
-    <value>The amount of physical memory allocated to this VM is greater than the total memory of its home server</value>
-  </data>
-  <data name="MemWarningLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="MemWarningLabel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;MemWarningLabel.Name" xml:space="preserve">
-    <value>MemWarningLabel</value>
-  </data>
-  <data name="&gt;&gt;MemWarningLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;MemWarningLabel.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;MemWarningLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="memorySpinner.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="memorySpinner.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="memorySpinner.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 234</value>
-  </data>
-  <data name="memorySpinner.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="memorySpinner.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 26</value>
-  </data>
-  <data name="memorySpinner.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;memorySpinner.Name" xml:space="preserve">
-    <value>memorySpinner</value>
-  </data>
-  <data name="&gt;&gt;memorySpinner.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.Ballooning.MemorySpinner, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;memorySpinner.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;memorySpinner.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="panel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -688,10 +529,7 @@
     <value>3</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 168</value>
-  </data>
-  <data name="panel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 24</value>
+    <value>3, 190</value>
   </data>
   <data name="panel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 6</value>
@@ -700,7 +538,7 @@
     <value>494, 42</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;panel1.Name" xml:space="preserve">
     <value>panel1</value>
@@ -712,34 +550,28 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>5</value>
+  </data>
+  <data name="lblVCPUs.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="lblVCPUs.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="lblVCPUs.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
   </data>
   <data name="lblVCPUs.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="lblVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 44</value>
-  </data>
-  <data name="lblVCPUs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>3, 80</value>
   </data>
   <data name="lblVCPUs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 21</value>
+    <value>95, 13</value>
   </data>
   <data name="lblVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="lblVCPUs.Text" xml:space="preserve">
     <value>&amp;Number of vCPUs:</value>
-  </data>
-  <data name="lblVCPUs.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;lblVCPUs.Name" xml:space="preserve">
     <value>lblVCPUs</value>
@@ -751,46 +583,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblVCPUs.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="lblMemory.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblMemory.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="lblMemory.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblMemory.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 237</value>
-  </data>
-  <data name="lblMemory.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="lblMemory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
-  </data>
-  <data name="lblMemory.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="lblMemory.Text" xml:space="preserve">
-    <value>&amp;VM memory:</value>
-  </data>
-  <data name="lblMemory.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblMemory.Name" xml:space="preserve">
-    <value>lblMemory</value>
-  </data>
-  <data name="&gt;&gt;lblMemory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMemory.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;lblMemory.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>7</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -804,11 +597,11 @@
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 0</value>
   </data>
-  <data name="label1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 15</value>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 15</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>494, 41</value>
+    <value>494, 26</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -826,16 +619,16 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>8</value>
   </data>
   <data name="comboBoxVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 44</value>
+    <value>129, 76</value>
   </data>
   <data name="comboBoxVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 21</value>
   </data>
   <data name="comboBoxVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;comboBoxVCPUs.Name" xml:space="preserve">
     <value>comboBoxVCPUs</value>
@@ -847,7 +640,97 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboBoxVCPUs.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="tableLayoutPanelInfo.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tableLayoutPanelInfo.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="tableLayoutPanelInfo.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="pictureBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Name" xml:space="preserve">
+    <value>pictureBox1</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.Parent" xml:space="preserve">
+    <value>tableLayoutPanelInfo</value>
+  </data>
+  <data name="&gt;&gt;pictureBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelInfo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="labelInfo.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>25, 4</value>
+  </data>
+  <data name="labelInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 13</value>
+  </data>
+  <data name="labelInfo.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;labelInfo.Name" xml:space="preserve">
+    <value>labelInfo</value>
+  </data>
+  <data name="&gt;&gt;labelInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelInfo.Parent" xml:space="preserve">
+    <value>tableLayoutPanelInfo</value>
+  </data>
+  <data name="&gt;&gt;labelInfo.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanelInfo.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanelInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 41</value>
+  </data>
+  <data name="tableLayoutPanelInfo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 10</value>
+  </data>
+  <data name="tableLayoutPanelInfo.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tableLayoutPanelInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>500, 22</value>
+  </data>
+  <data name="tableLayoutPanelInfo.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelInfo.Name" xml:space="preserve">
+    <value>tableLayoutPanelInfo</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelInfo.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanelInfo.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="tableLayoutPanelInfo.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="pictureBox1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelInfo" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -859,10 +742,10 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>8</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>500, 500</value>
+    <value>500, 400</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -880,22 +763,22 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="warningsTableLayoutPanel" Row="12" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxTopology" Row="4" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="labelTopology" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="MemWarningLabel" Row="10" RowSpan="2" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="memorySpinner" Row="10" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="panel1" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblPriority" Row="8" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="lblVCPUs" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblMemory" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="comboBoxVCPUs" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,45,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,100,Percent,50,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="warningsTableLayoutPanel" Row="7" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxTopology" Row="3" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelTopology" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="panel1" Row="6" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="lblPriority" Row="5" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="lblVCPUs" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="comboBoxVCPUs" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanelInfo" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="lblPriority.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="lblPriority.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 142</value>
+    <value>3, 174</value>
   </data>
-  <data name="lblPriority.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 10, 0, 0</value>
+  <data name="lblPriority.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 20, 3, 0</value>
   </data>
   <data name="lblPriority.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 23</value>
+    <value>179, 13</value>
   </data>
   <data name="lblPriority.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="lblPriority.Text" xml:space="preserve">
     <value>vCPU priority for this virtual machine:</value>
@@ -913,7 +796,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblPriority.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>6</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -925,10 +808,10 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>500, 500</value>
+    <value>500, 400</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>500, 500</value>
+    <value>500, 400</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>CpuMemoryEditPage</value>

--- a/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateWizard.cs
+++ b/XenAdmin/Wizards/CrossPoolMigrateWizard/CrossPoolMigrateWizard.cs
@@ -469,7 +469,6 @@ namespace XenAdmin.Wizards.CrossPoolMigrateWizard
                     summary = new VmTitleSummary(summary, pair.Value);
 
                 summary = new DestinationPoolSummary(summary, pair.Value, TargetConnection);
-                summary = new TargetServerSummary(summary, pair.Value, TargetConnection);
                 summary = new TransferNetworkSummary(summary, m_pageTransferNetwork.NetworkUuid.Value);
                 summary = new StorageSummary(summary, pair.Value, xenConnection);
                 summary = new NetworkSummary(summary, pair.Value, xenConnection);

--- a/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
+++ b/XenAdmin/Wizards/GenericPages/SelectMultipleVMDestinationPage.cs
@@ -49,7 +49,6 @@ namespace XenAdmin.Wizards.GenericPages
     internal abstract partial class SelectMultipleVMDestinationPage : XenTabPage
     {
         private Dictionary<string, VmMapping> m_vmMappings;
-        public IXenObject SelectedTarget { get; set; }
         private bool updatingDestinationCombobox;
         private bool restoreGridHomeServerSelection;
         private bool updatingHomeServerList;
@@ -58,6 +57,7 @@ namespace XenAdmin.Wizards.GenericPages
         private readonly CollectionChangeEventHandler Host_CollectionChangedWithInvoke;
         private string _preferredHomeRef;
         private IXenObject _selectedTargetPool;
+        private IXenObject _selectedTarget;
 
         #region Nested classes
 
@@ -121,8 +121,24 @@ namespace XenAdmin.Wizards.GenericPages
             get => _selectedTargetPool;
             private set
             {
+                var oldTargetPool = _selectedTargetPool;
                 _selectedTargetPool = value;
-                OnChosenItemChanged();
+
+                if (oldTargetPool?.opaque_ref != _selectedTargetPool?.opaque_ref)
+                    OnSelectedTargetPoolChanged();
+            }
+        }
+
+        public IXenObject SelectedTarget
+        {
+            get => _selectedTarget;
+            set
+            {
+                var oldTarget = _selectedTarget;
+                _selectedTarget = value;
+
+                if (oldTarget?.opaque_ref != SelectedTarget?.opaque_ref)
+                    OnSelectedTargetChanged();
             }
         }
 
@@ -143,8 +159,13 @@ namespace XenAdmin.Wizards.GenericPages
         /// </summary>
         protected abstract string TargetServerSelectionIntroText { get; }
 
-        protected virtual void OnChosenItemChanged()
+        protected virtual void OnSelectedTargetPoolChanged()
         { }
+
+        protected virtual void OnSelectedTargetChanged()
+        {
+
+        }
 
         protected void ShowWarning(string warningText)
         {

--- a/XenAdmin/Wizards/GenericPages/VMMappingSummary.cs
+++ b/XenAdmin/Wizards/GenericPages/VMMappingSummary.cs
@@ -166,46 +166,6 @@ namespace XenAdmin.Wizards.GenericPages
         }
     }
 
-    public class TargetServerSummary : MappingSummaryDecorator
-    {
-        private readonly VmMapping mapping;
-        private readonly IXenConnection connection;
-
-        public TargetServerSummary(MappingSummary summary, VmMapping mapping, IXenConnection connection)
-            : base(summary)
-        {
-            this.mapping = mapping;
-            this.connection = connection;
-        }
-
-        public override List<SummaryDetails> Details
-        {
-            get
-            {
-                List<SummaryDetails> decoratedSummary = summary.Details;
-                decoratedSummary.Add(new SummaryDetails(Messages.CPM_SUMMARY_KEY_HOME_SERVER, ResolveLabel()));
-                return decoratedSummary;
-            }
-        }
-
-        private string ResolveLabel()
-        {
-            if (mapping.XenRef is XenRef<Host>)
-            {
-                Host targetHost = connection.Resolve(mapping.XenRef as XenRef<Host>);
-
-                if (targetHost == null)
-                {
-                    return Messages.UNKNOWN;
-                }
-
-                return mapping.TargetName;
-            }
-
-            return Messages.CPM_SUMMARY_UNSET;
-        }
-    }
-
     public class StorageSummary : MappingSummaryDecorator
     {
         private readonly VmMapping mapping;
@@ -355,9 +315,6 @@ namespace XenAdmin.Wizards.GenericPages
             this.summary = summary;
         }
  
-        public override List<SummaryDetails> Details
-        {
-            get { return summary != null ? summary.Details : new List<SummaryDetails>(); }
-        }
+        public override List<SummaryDetails> Details => summary != null ? summary.Details : new List<SummaryDetails>();
     }
 }

--- a/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportSelectHostPage.cs
@@ -127,29 +127,35 @@ namespace XenAdmin.Wizards.ImportWizard
                             }
                         }
                         // Memory
-                        if (rasdType.ResourceType.Value == 4 && long.TryParse(rasdType.VirtualQuantity.Value.ToString(), out var memory))
+                        if (rasdType.ResourceType.Value == 4 && double.TryParse(rasdType.VirtualQuantity.Value.ToString(), out var memory))
                         {
                             //The default memory unit is MB (2^20), however, the RASD may contain a different
                             //one with format byte*memoryBase^memoryPower (byte being a literal string)
 
-                            double memoryPower = 20.0;
                             double memoryBase = 2.0;
+                            double memoryPower = 20.0;
 
                             if (rasdType.AllocationUnits.Value.ToLower().StartsWith("byte"))
                             {
                                 string[] a1 = rasdType.AllocationUnits.Value.Split('*', '^');
+
                                 if (a1.Length == 3)
                                 {
-                                    memoryBase = Convert.ToDouble(a1[1].Trim());
-                                    memoryPower = Convert.ToDouble(a1[2].Trim());
+                                    if (!double.TryParse(a1[1].Trim(), out memoryBase))
+                                        memoryBase = 2.0;
+                                    if (!double.TryParse(a1[2].Trim(), out memoryPower))
+                                        memoryPower = 20.0;
                                 }
                             }
 
                             double memoryMultiplier = Math.Pow(memoryBase, memoryPower);
-                            memory *= (long)memoryMultiplier;
+                            memory *= memoryMultiplier;
+
+                            if (memory > long.MaxValue)
+                                memory = long.MaxValue;
 
                             if (_ovfMemory < memory)
-                                _ovfMemory = memory;
+                                _ovfMemory = (long)memory;
                         }
                     }
 

--- a/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
+++ b/XenAdmin/Wizards/ImportWizard/ImportWizard.cs
@@ -582,7 +582,7 @@ namespace XenAdmin.Wizards.ImportWizard
         {
             var temp = new List<Tuple>();
             temp.Add(new Tuple(Messages.FINISH_PAGE_VMNAME, m_pageXvaStorage.ImportedVm.Name()));
-            temp.Add(new Tuple(Messages.FINISH_PAGE_TARGET, m_pageXvaHost.SelectedHost == null ? m_pageXvaHost.SelectedConnection.Name : m_pageXvaHost.SelectedHost.Name()));
+            temp.Add(new Tuple(Messages.FINISH_PAGE_TARGET_FOR_VM, m_pageXvaHost.SelectedHost == null ? m_pageXvaHost.SelectedConnection.Name : m_pageXvaHost.SelectedHost.Name()));
             temp.Add(new Tuple(Messages.FINISH_PAGE_STORAGE, m_pageXvaStorage.SR.Name()));
 
             var con = m_pageXvaHost.SelectedHost == null ? m_pageXvaHost.SelectedConnection : m_pageXvaHost.SelectedHost.Connection;

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.Designer.cs
@@ -48,26 +48,30 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.spinnerStatMax = new XenAdmin.Controls.Ballooning.MemorySpinner();
             this.label5 = new System.Windows.Forms.Label();
             this.comboBoxTopology = new XenAdmin.Controls.CPUTopologyComboBox();
-            this.labelInvalidVCPUWarning = new System.Windows.Forms.Label();
             this.labelInitialVCPUs = new System.Windows.Forms.Label();
             this.comboBoxInitialVCPUs = new System.Windows.Forms.ComboBox();
             this.initialVCPUWarningLabel = new System.Windows.Forms.Label();
             this.vCPUWarningLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.pictureBoxTopology = new System.Windows.Forms.PictureBox();
+            this.labelTopologyWarning = new System.Windows.Forms.Label();
             this.warningsTableLayoutPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.cpuWarningPictureBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).BeginInit();
             this.tableLayoutPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxTopology)).BeginInit();
             this.SuspendLayout();
             // 
             // warningsTableLayoutPanel
             // 
             resources.ApplyResources(this.warningsTableLayoutPanel, "warningsTableLayoutPanel");
             this.tableLayoutPanel1.SetColumnSpan(this.warningsTableLayoutPanel, 4);
+            this.warningsTableLayoutPanel.Controls.Add(this.pictureBoxTopology, 0, 2);
             this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningPictureBox, 0, 0);
             this.warningsTableLayoutPanel.Controls.Add(this.cpuWarningLabel, 1, 0);
-            this.warningsTableLayoutPanel.Controls.Add(this.memoryWarningLabel, 1, 1);
-            this.warningsTableLayoutPanel.Controls.Add(this.memoryPictureBox, 0, 1);
+            this.warningsTableLayoutPanel.Controls.Add(this.memoryWarningLabel, 1, 4);
+            this.warningsTableLayoutPanel.Controls.Add(this.memoryPictureBox, 0, 4);
+            this.warningsTableLayoutPanel.Controls.Add(this.labelTopologyWarning, 1, 2);
             this.warningsTableLayoutPanel.Name = "warningsTableLayoutPanel";
             // 
             // cpuWarningPictureBox
@@ -181,13 +185,6 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.comboBoxTopology.Name = "comboBoxTopology";
             this.comboBoxTopology.SelectedIndexChanged += new System.EventHandler(this.comboBoxTopology_SelectedIndexChanged);
             // 
-            // labelInvalidVCPUWarning
-            // 
-            resources.ApplyResources(this.labelInvalidVCPUWarning, "labelInvalidVCPUWarning");
-            this.tableLayoutPanel1.SetColumnSpan(this.labelInvalidVCPUWarning, 3);
-            this.labelInvalidVCPUWarning.ForeColor = System.Drawing.Color.Red;
-            this.labelInvalidVCPUWarning.Name = "labelInvalidVCPUWarning";
-            // 
             // labelInitialVCPUs
             // 
             resources.ApplyResources(this.labelInitialVCPUs, "labelInitialVCPUs");
@@ -219,26 +216,37 @@ namespace XenAdmin.Wizards.NewVMWizard
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
             this.tableLayoutPanel1.Controls.Add(this.vCPUWarningLabel, 2, 1);
-            this.tableLayoutPanel1.Controls.Add(this.initialVCPUWarningLabel, 2, 4);
-            this.tableLayoutPanel1.Controls.Add(this.comboBoxInitialVCPUs, 1, 4);
-            this.tableLayoutPanel1.Controls.Add(this.labelInitialVCPUs, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.labelInvalidVCPUWarning, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.initialVCPUWarningLabel, 2, 3);
+            this.tableLayoutPanel1.Controls.Add(this.comboBoxInitialVCPUs, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.labelInitialVCPUs, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxTopology, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.label5, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.spinnerStatMax, 1, 8);
+            this.tableLayoutPanel1.Controls.Add(this.spinnerStatMax, 1, 7);
             this.tableLayoutPanel1.Controls.Add(this.labelVCPUs, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.spinnerDynMax, 1, 7);
+            this.tableLayoutPanel1.Controls.Add(this.spinnerDynMax, 1, 6);
             this.tableLayoutPanel1.Controls.Add(this.labelTopology, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.comboBoxVCPUs, 1, 1);
-            this.tableLayoutPanel1.Controls.Add(this.spinnerDynMin, 1, 6);
-            this.tableLayoutPanel1.Controls.Add(this.labelDynMin, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.labelDynMax, 0, 7);
-            this.tableLayoutPanel1.Controls.Add(this.labelStatMax, 0, 8);
-            this.tableLayoutPanel1.Controls.Add(this.labelDynMinInfo, 3, 6);
-            this.tableLayoutPanel1.Controls.Add(this.labelDynMaxInfo, 3, 7);
-            this.tableLayoutPanel1.Controls.Add(this.labelStatMaxInfo, 3, 8);
-            this.tableLayoutPanel1.Controls.Add(this.warningsTableLayoutPanel, 0, 9);
+            this.tableLayoutPanel1.Controls.Add(this.spinnerDynMin, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.labelDynMin, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.labelDynMax, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.labelStatMax, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.labelDynMinInfo, 3, 5);
+            this.tableLayoutPanel1.Controls.Add(this.labelDynMaxInfo, 3, 6);
+            this.tableLayoutPanel1.Controls.Add(this.labelStatMaxInfo, 3, 7);
+            this.tableLayoutPanel1.Controls.Add(this.warningsTableLayoutPanel, 0, 8);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // pictureBoxTopology
+            // 
+            this.pictureBoxTopology.Image = global::XenAdmin.Properties.Resources._000_Alert2_h32bit_16;
+            resources.ApplyResources(this.pictureBoxTopology, "pictureBoxTopology");
+            this.pictureBoxTopology.Name = "pictureBoxTopology";
+            this.pictureBoxTopology.TabStop = false;
+            // 
+            // labelTopologyWarning
+            // 
+            resources.ApplyResources(this.labelTopologyWarning, "labelTopologyWarning");
+            this.labelTopologyWarning.Name = "labelTopologyWarning";
             // 
             // Page_CpuMem
             // 
@@ -252,6 +260,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             ((System.ComponentModel.ISupportInitialize)(this.memoryPictureBox)).EndInit();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxTopology)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -264,7 +273,6 @@ namespace XenAdmin.Wizards.NewVMWizard
         private System.Windows.Forms.Label initialVCPUWarningLabel;
         private System.Windows.Forms.ComboBox comboBoxInitialVCPUs;
         private System.Windows.Forms.Label labelInitialVCPUs;
-        private System.Windows.Forms.Label labelInvalidVCPUWarning;
         private Controls.CPUTopologyComboBox comboBoxTopology;
         private System.Windows.Forms.Label label5;
         private Controls.Ballooning.MemorySpinner spinnerStatMax;
@@ -283,5 +291,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         private System.Windows.Forms.Label cpuWarningLabel;
         private System.Windows.Forms.Label memoryWarningLabel;
         private System.Windows.Forms.PictureBox memoryPictureBox;
+        private System.Windows.Forms.PictureBox pictureBoxTopology;
+        private System.Windows.Forms.Label labelTopologyWarning;
     }
 }

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.cs
@@ -151,8 +151,8 @@ namespace XenAdmin.Wizards.NewVMWizard
             InitialiseVCpuControls();
             SetSpinnerLimitsAndIncrement();
             ValidateMemorySettings();
-            ValidateVcpuSettings();
-            ValidateInitialVcpuSettings();
+            ValidateVCpuSettings();
+            ValidateInitialVCpuSettings();
             OnPageUpdated();
 
             _initializing = false;
@@ -344,9 +344,9 @@ namespace XenAdmin.Wizards.NewVMWizard
             }
         }
 
-        private void ValidateVcpuSettings()
+        private void ValidateVCpuSettings()
         {
-            Host maxVcpusHost = null;
+            Host maxVCpusHost = null;
             _maxVCpus = 0;
 
             var warnings = new List<string>();
@@ -364,13 +364,13 @@ namespace XenAdmin.Wizards.NewVMWizard
                 if (hostCpus > _maxVCpus)
                 {
                     _maxVCpus = hostCpus;
-                    maxVcpusHost = host;
+                    maxVCpusHost = host;
                 }
             }
 
-            if (maxVcpusHost != null && SelectedVCpusMax > _maxVCpus)
+            if (maxVCpusHost != null && SelectedVCpusMax > _maxVCpus)
             {
-                var isStandAloneHost = Helpers.GetPool(maxVcpusHost.Connection) == null;
+                var isStandAloneHost = Helpers.GetPool(maxVCpusHost.Connection) == null;
                 if (isStandAloneHost)
                 {
                     warnings.Add(string.Format(Messages.NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST, SelectedVCpusMax, _maxVCpus));
@@ -399,7 +399,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             }
         }
 
-        private void ValidateInitialVcpuSettings()
+        private void ValidateInitialVCpuSettings()
         {
             if (SelectedVCpusAtStartup < _minVCpus)
             {
@@ -457,7 +457,7 @@ namespace XenAdmin.Wizards.NewVMWizard
         private void vCPU_ValueChanged(object sender, EventArgs e)
         {
             comboBoxTopology.Update((long)comboBoxVCPUs.SelectedItem);
-            ValidateVcpuSettings();
+            ValidateVCpuSettings();
             RefreshCurrentVCpus();
             OnPageUpdated();
         }
@@ -500,7 +500,7 @@ namespace XenAdmin.Wizards.NewVMWizard
 
         private void comboBoxInitialVCPUs_SelectedIndexChanged(object sender, EventArgs e)
         {
-           ValidateInitialVcpuSettings();
+            ValidateInitialVCpuSettings();
         }
 
         #endregion

--- a/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_CpuMem.resx
@@ -142,13 +142,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="vCPUWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>185, 40</value>
+    <value>185, 38</value>
   </data>
   <data name="vCPUWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>327, 27</value>
   </data>
   <data name="vCPUWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
+    <value>2</value>
   </data>
   <data name="vCPUWarningLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -178,13 +178,13 @@
     <value>NoControl</value>
   </data>
   <data name="initialVCPUWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>185, 113</value>
+    <value>185, 92</value>
   </data>
   <data name="initialVCPUWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>327, 27</value>
   </data>
   <data name="initialVCPUWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>7</value>
   </data>
   <data name="initialVCPUWarningLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -205,7 +205,7 @@
     <value>1</value>
   </data>
   <data name="comboBoxInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 116</value>
+    <value>129, 95</value>
   </data>
   <data name="comboBoxInitialVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 21</value>
@@ -235,7 +235,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelInitialVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 120</value>
+    <value>3, 99</value>
   </data>
   <data name="labelInitialVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 13</value>
@@ -245,9 +245,6 @@
   </data>
   <data name="labelInitialVCPUs.Text" xml:space="preserve">
     <value>Initial number of v&amp;CPUs:</value>
-  </data>
-  <data name="labelInitialVCPUs.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;labelInitialVCPUs.Name" xml:space="preserve">
     <value>labelInitialVCPUs</value>
@@ -261,44 +258,11 @@
   <data name="&gt;&gt;labelInitialVCPUs.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="labelInvalidVCPUWarning.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 94</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 6</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.Size" type="System.Drawing.Size, System.Drawing">
-    <value>383, 13</value>
-  </data>
-  <data name="labelInvalidVCPUWarning.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.Name" xml:space="preserve">
-    <value>labelInvalidVCPUWarning</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.Parent" xml:space="preserve">
-    <value>tableLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;labelInvalidVCPUWarning.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="comboBoxTopology.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8pt</value>
   </data>
   <data name="comboBoxTopology.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 70</value>
+    <value>129, 68</value>
   </data>
   <data name="comboBoxTopology.Size" type="System.Drawing.Size, System.Drawing">
     <value>250, 21</value>
@@ -316,7 +280,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboBoxTopology.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>4</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -331,7 +295,7 @@
     <value>3, 0</value>
   </data>
   <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 14</value>
+    <value>3, 0, 3, 12</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
     <value>509, 26</value>
@@ -352,7 +316,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="spinnerStatMax.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -361,7 +325,7 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="spinnerStatMax.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 212</value>
+    <value>126, 191</value>
   </data>
   <data name="spinnerStatMax.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -370,7 +334,7 @@
     <value>97, 26</value>
   </data>
   <data name="spinnerStatMax.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>15</value>
   </data>
   <data name="&gt;&gt;spinnerStatMax.Name" xml:space="preserve">
     <value>spinnerStatMax</value>
@@ -382,7 +346,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;spinnerStatMax.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>6</value>
   </data>
   <data name="labelVCPUs.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -394,7 +358,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 47</value>
+    <value>3, 45</value>
   </data>
   <data name="labelVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>95, 13</value>
@@ -404,9 +368,6 @@
   </data>
   <data name="labelVCPUs.Text" xml:space="preserve">
     <value>&amp;Number of vCPUs:</value>
-  </data>
-  <data name="labelVCPUs.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;labelVCPUs.Name" xml:space="preserve">
     <value>labelVCPUs</value>
@@ -418,7 +379,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelVCPUs.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="spinnerDynMax.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -427,7 +388,7 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="spinnerDynMax.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 186</value>
+    <value>126, 165</value>
   </data>
   <data name="spinnerDynMax.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -436,7 +397,7 @@
     <value>97, 26</value>
   </data>
   <data name="spinnerDynMax.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>12</value>
   </data>
   <data name="&gt;&gt;spinnerDynMax.Name" xml:space="preserve">
     <value>spinnerDynMax</value>
@@ -448,7 +409,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;spinnerDynMax.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>8</value>
   </data>
   <data name="labelTopology.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -460,7 +421,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelTopology.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 74</value>
+    <value>3, 72</value>
   </data>
   <data name="labelTopology.Size" type="System.Drawing.Size, System.Drawing">
     <value>54, 13</value>
@@ -470,9 +431,6 @@
   </data>
   <data name="labelTopology.Text" xml:space="preserve">
     <value>&amp;Topology:</value>
-  </data>
-  <data name="labelTopology.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;labelTopology.Name" xml:space="preserve">
     <value>labelTopology</value>
@@ -484,16 +442,16 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelTopology.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>9</value>
   </data>
   <data name="comboBoxVCPUs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 43</value>
+    <value>129, 41</value>
   </data>
   <data name="comboBoxVCPUs.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 21</value>
   </data>
   <data name="comboBoxVCPUs.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;comboBoxVCPUs.Name" xml:space="preserve">
     <value>comboBoxVCPUs</value>
@@ -505,7 +463,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;comboBoxVCPUs.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>10</value>
   </data>
   <data name="spinnerDynMin.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -514,7 +472,7 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="spinnerDynMin.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 160</value>
+    <value>126, 139</value>
   </data>
   <data name="spinnerDynMin.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -523,7 +481,7 @@
     <value>97, 26</value>
   </data>
   <data name="spinnerDynMin.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;spinnerDynMin.Name" xml:space="preserve">
     <value>spinnerDynMin</value>
@@ -535,7 +493,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;spinnerDynMin.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>11</value>
   </data>
   <data name="labelDynMin.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -547,13 +505,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelDynMin.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 166</value>
+    <value>3, 145</value>
   </data>
   <data name="labelDynMin.Size" type="System.Drawing.Size, System.Drawing">
     <value>90, 13</value>
   </data>
   <data name="labelDynMin.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="labelDynMin.Text" xml:space="preserve">
     <value>&amp;Minimum memory:</value>
@@ -568,7 +526,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelDynMin.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>12</value>
   </data>
   <data name="labelDynMax.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -580,13 +538,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelDynMax.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 192</value>
+    <value>3, 171</value>
   </data>
   <data name="labelDynMax.Size" type="System.Drawing.Size, System.Drawing">
     <value>93, 13</value>
   </data>
   <data name="labelDynMax.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="labelDynMax.Text" xml:space="preserve">
     <value>Ma&amp;ximum memory:</value>
@@ -601,7 +559,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelDynMax.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>13</value>
   </data>
   <data name="labelStatMax.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -613,13 +571,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelStatMax.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 218</value>
+    <value>3, 197</value>
   </data>
   <data name="labelStatMax.Size" type="System.Drawing.Size, System.Drawing">
     <value>83, 13</value>
   </data>
   <data name="labelStatMax.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>14</value>
   </data>
   <data name="labelStatMax.Text" xml:space="preserve">
     <value>&amp;Static maximum:</value>
@@ -634,7 +592,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelStatMax.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>14</value>
   </data>
   <data name="labelDynMinInfo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -646,13 +604,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelDynMinInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>226, 166</value>
+    <value>226, 145</value>
   </data>
   <data name="labelDynMinInfo.Size" type="System.Drawing.Size, System.Drawing">
     <value>155, 13</value>
   </data>
   <data name="labelDynMinInfo.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>10</value>
   </data>
   <data name="labelDynMinInfo.Text" xml:space="preserve">
     <value>Minimum maximum placeholder.</value>
@@ -667,7 +625,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelDynMinInfo.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>15</value>
   </data>
   <data name="labelDynMaxInfo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -679,13 +637,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelDynMaxInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>226, 192</value>
+    <value>226, 171</value>
   </data>
   <data name="labelDynMaxInfo.Size" type="System.Drawing.Size, System.Drawing">
     <value>155, 13</value>
   </data>
   <data name="labelDynMaxInfo.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>13</value>
   </data>
   <data name="labelDynMaxInfo.Text" xml:space="preserve">
     <value>Minimum maximum placeholder.</value>
@@ -700,7 +658,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelDynMaxInfo.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>16</value>
   </data>
   <data name="labelStatMaxInfo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -712,7 +670,7 @@
     <value>NoControl</value>
   </data>
   <data name="labelStatMaxInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>226, 218</value>
+    <value>226, 197</value>
   </data>
   <data name="labelStatMaxInfo.Size" type="System.Drawing.Size, System.Drawing">
     <value>155, 13</value>
@@ -733,7 +691,7 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;labelStatMaxInfo.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>17</value>
   </data>
   <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -742,7 +700,7 @@
     <value>0, 0</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>9</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>515, 367</value>
@@ -763,22 +721,43 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="vCPUWarningLabel" Row="1" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="initialVCPUWarningLabel" Row="4" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelInvalidVCPUWarning" Row="3" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="comboBoxTopology" Row="2" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="label5" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="spinnerStatMax" Row="8" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelVCPUs" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMax" Row="7" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelTopology" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxVCPUs" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMin" Row="6" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelDynMin" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMax" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMax" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMinInfo" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMaxInfo" Row="7" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMaxInfo" Row="8" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="warningsTableLayoutPanel" Row="9" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,41,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="vCPUWarningLabel" Row="1" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="initialVCPUWarningLabel" Row="3" RowSpan="1" Column="2" ColumnSpan="2" /&gt;&lt;Control Name="comboBoxInitialVCPUs" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelInitialVCPUs" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxTopology" Row="2" RowSpan="1" Column="1" ColumnSpan="3" /&gt;&lt;Control Name="label5" Row="0" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;Control Name="spinnerStatMax" Row="7" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelVCPUs" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMax" Row="6" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelTopology" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="comboBoxVCPUs" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="spinnerDynMin" Row="5" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="labelDynMin" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMax" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMax" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMinInfo" Row="5" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelDynMaxInfo" Row="6" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="labelStatMaxInfo" Row="7" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="warningsTableLayoutPanel" Row="8" RowSpan="1" Column="0" ColumnSpan="4" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,Absolute,41,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="pictureBoxTopology.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="pictureBoxTopology.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 31</value>
+  </data>
+  <data name="pictureBoxTopology.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="pictureBoxTopology.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="pictureBoxTopology.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxTopology.Name" xml:space="preserve">
+    <value>pictureBoxTopology</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxTopology.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxTopology.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;pictureBoxTopology.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="cpuWarningPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="cpuWarningPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 3</value>
-  </data>
-  <data name="cpuWarningPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>3, 3</value>
   </data>
   <data name="cpuWarningPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 16</value>
-  </data>
-  <data name="cpuWarningPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
+    <value>16, 16</value>
   </data>
   <data name="cpuWarningPictureBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -796,7 +775,10 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cpuWarningPictureBox.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
+  </data>
+  <data name="cpuWarningLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="cpuWarningLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -805,16 +787,13 @@
     <value>NoControl</value>
   </data>
   <data name="cpuWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 3</value>
-  </data>
-  <data name="cpuWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>25, 4</value>
   </data>
   <data name="cpuWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 13</value>
   </data>
   <data name="cpuWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="cpuWarningLabel.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -829,7 +808,10 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cpuWarningLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
+  </data>
+  <data name="memoryWarningLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="memoryWarningLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -838,16 +820,13 @@
     <value>NoControl</value>
   </data>
   <data name="memoryWarningLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 25</value>
-  </data>
-  <data name="memoryWarningLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>25, 60</value>
   </data>
   <data name="memoryWarningLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 13</value>
   </data>
   <data name="memoryWarningLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>2</value>
   </data>
   <data name="memoryWarningLabel.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -862,22 +841,16 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;memoryWarningLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="memoryPictureBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="memoryPictureBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="memoryPictureBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>3, 59</value>
   </data>
   <data name="memoryPictureBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 16</value>
-  </data>
-  <data name="memoryPictureBox.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
-    <value>CenterImage</value>
+    <value>16, 16</value>
   </data>
   <data name="memoryPictureBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -895,25 +868,55 @@
     <value>warningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;memoryPictureBox.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
+  </data>
+  <data name="labelTopologyWarning.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="labelTopologyWarning.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelTopologyWarning.Location" type="System.Drawing.Point, System.Drawing">
+    <value>25, 32</value>
+  </data>
+  <data name="labelTopologyWarning.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 13</value>
+  </data>
+  <data name="labelTopologyWarning.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="labelTopologyWarning.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;labelTopologyWarning.Name" xml:space="preserve">
+    <value>labelTopologyWarning</value>
+  </data>
+  <data name="&gt;&gt;labelTopologyWarning.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelTopologyWarning.Parent" xml:space="preserve">
+    <value>warningsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;labelTopologyWarning.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="warningsTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
+    <value>Top</value>
   </data>
   <data name="warningsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 320</value>
+    <value>0, 237</value>
   </data>
   <data name="warningsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>0, 20, 0, 0</value>
   </data>
   <data name="warningsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>5</value>
   </data>
   <data name="warningsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>515, 44</value>
+    <value>515, 78</value>
   </data>
   <data name="warningsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>17</value>
   </data>
   <data name="&gt;&gt;warningsTableLayoutPanel.Name" xml:space="preserve">
     <value>warningsTableLayoutPanel</value>
@@ -925,10 +928,10 @@
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;warningsTableLayoutPanel.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>18</value>
   </data>
   <data name="warningsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryWarningLabel" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryPictureBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,30,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="pictureBoxTopology" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningPictureBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cpuWarningLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryWarningLabel" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="memoryPictureBox" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="labelTopologyWarning" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Absolute,6,AutoSize,0,Absolute,6,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/XenAdmin/Wizards/NewVMWizard/Page_Finish.Designer.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Finish.Designer.cs
@@ -31,21 +31,15 @@ namespace XenAdmin.Wizards.NewVMWizard
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Page_Finish));
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            this.richTextBox1 = new System.Windows.Forms.RichTextBox();
             this.AutoStartCheckBox = new System.Windows.Forms.CheckBox();
             this.SummaryGridView = new XenAdmin.Controls.DataGridViewEx.DataGridViewEx();
             this.PropertyColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ValueColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.label1 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.SummaryGridView)).BeginInit();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // richTextBox1
-            // 
-            resources.ApplyResources(this.richTextBox1, "richTextBox1");
-            this.richTextBox1.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.richTextBox1.Name = "richTextBox1";
-            this.richTextBox1.ReadOnly = true;
-            this.richTextBox1.TabStop = false;
             // 
             // AutoStartCheckBox
             // 
@@ -57,9 +51,9 @@ namespace XenAdmin.Wizards.NewVMWizard
             // 
             // SummaryGridView
             // 
-            resources.ApplyResources(this.SummaryGridView, "SummaryGridView");
             this.SummaryGridView.BackgroundColor = System.Drawing.SystemColors.Control;
             this.SummaryGridView.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
+            this.SummaryGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             this.SummaryGridView.ColumnHeadersVisible = false;
             this.SummaryGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.PropertyColumn,
@@ -72,6 +66,7 @@ namespace XenAdmin.Wizards.NewVMWizard
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
             this.SummaryGridView.DefaultCellStyle = dataGridViewCellStyle1;
+            resources.ApplyResources(this.SummaryGridView, "SummaryGridView");
             this.SummaryGridView.Name = "SummaryGridView";
             this.SummaryGridView.ReadOnly = true;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Control;
@@ -94,26 +89,38 @@ namespace XenAdmin.Wizards.NewVMWizard
             this.ValueColumn.Name = "ValueColumn";
             this.ValueColumn.ReadOnly = true;
             // 
+            // tableLayoutPanel1
+            // 
+            resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.AutoStartCheckBox, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.SummaryGridView, 0, 1);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // label1
+            // 
+            resources.ApplyResources(this.label1, "label1");
+            this.label1.Name = "label1";
+            // 
             // Page_Finish
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.Controls.Add(this.SummaryGridView);
-            this.Controls.Add(this.AutoStartCheckBox);
-            this.Controls.Add(this.richTextBox1);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "Page_Finish";
             ((System.ComponentModel.ISupportInitialize)(this.SummaryGridView)).EndInit();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
         #endregion
-
-        private System.Windows.Forms.RichTextBox richTextBox1;
         private System.Windows.Forms.CheckBox AutoStartCheckBox;
         private XenAdmin.Controls.DataGridViewEx.DataGridViewEx SummaryGridView;
         private System.Windows.Forms.DataGridViewTextBoxColumn PropertyColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn ValueColumn;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Finish.cs
@@ -40,7 +40,6 @@ namespace XenAdmin.Wizards.NewVMWizard
         public Page_Finish()
         {
             InitializeComponent();
-            richTextBox1.Text = Messages.NEWVMWIZARD_FINISHPAGE;
         }
 
         public override string Text => Messages.NEWVMWIZARD_FINISHPAGE_NAME;

--- a/XenAdmin/Wizards/NewVMWizard/Page_Finish.resx
+++ b/XenAdmin/Wizards/NewVMWizard/Page_Finish.resx
@@ -112,49 +112,22 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="richTextBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="richTextBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 4</value>
-  </data>
-  <data name="richTextBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>508, 86</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="richTextBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="richTextBox1.Text" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;richTextBox1.Name" xml:space="preserve">
-    <value>richTextBox1</value>
-  </data>
-  <data name="&gt;&gt;richTextBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RichTextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;richTextBox1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;richTextBox1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="AutoStartCheckBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
-  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="AutoStartCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="AutoStartCheckBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 288</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="AutoStartCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 10, 3, 3</value>
   </data>
   <data name="AutoStartCheckBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>172, 17</value>
@@ -169,18 +142,15 @@
     <value>AutoStartCheckBox</value>
   </data>
   <data name="&gt;&gt;AutoStartCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoStartCheckBox.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;AutoStartCheckBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="SummaryGridView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <metadata name="PropertyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="PropertyColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="PropertyColumn.HeaderText" xml:space="preserve">
@@ -189,17 +159,20 @@
   <data name="PropertyColumn.Width" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <metadata name="ValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="ValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="ValueColumn.HeaderText" xml:space="preserve">
     <value>Value</value>
   </data>
+  <data name="SummaryGridView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <data name="SummaryGridView.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 97</value>
+    <value>3, 44</value>
   </data>
   <data name="SummaryGridView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>508, 142</value>
+    <value>509, 231</value>
   </data>
   <data name="SummaryGridView.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -208,15 +181,81 @@
     <value>SummaryGridView</value>
   </data>
   <data name="&gt;&gt;SummaryGridView.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.DataGridViewEx.DataGridViewEx, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.DataGridViewEx.DataGridViewEx, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;SummaryGridView.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;SummaryGridView.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 15</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>509, 26</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="label1.Text" xml:space="preserve">
+    <value>All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>515, 308</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AutoStartCheckBox" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="SummaryGridView" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
@@ -229,18 +268,18 @@
     <value>PropertyColumn</value>
   </data>
   <data name="&gt;&gt;PropertyColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ValueColumn.Name" xml:space="preserve">
     <value>ValueColumn</value>
   </data>
   <data name="&gt;&gt;ValueColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>Page_Finish</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>XenAdmin.Controls.XenTabPage, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>XenAdmin.Controls.XenTabPage, [XenCenter_No_Space], Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/XenModel/Actions/OvfActions/Import.cs
+++ b/XenModel/Actions/OvfActions/Import.cs
@@ -492,18 +492,21 @@ namespace XenAdmin.Actions.OvfActions
                 //The default memory unit is MB (2^20), however, the RASD may contain a different
                 //one with format byte*memoryBase^memoryPower (byte being a literal string)
 
-                double memoryPower = 20.0;
                 double memoryBase = 2.0;
-               
+                double memoryPower = 20.0;
+
                 foreach (RASD_Type rasd in rasds)
                 {
                     if (rasd.AllocationUnits.Value.ToLower().StartsWith("byte"))
                     {
                         string[] a1 = rasd.AllocationUnits.Value.Split('*', '^');
+
                         if (a1.Length == 3)
                         {
-                            memoryBase = Convert.ToDouble(a1[1].Trim());
-                            memoryPower = Convert.ToDouble(a1[2].Trim());
+                            if (!double.TryParse(a1[1].Trim(), out memoryBase))
+                                memoryBase = 2.0;
+                            if (!double.TryParse(a1[2].Trim(), out memoryPower))
+                                memoryPower = 20.0;
                         }
                     }
 

--- a/XenModel/Actions/OvfActions/Import.cs
+++ b/XenModel/Actions/OvfActions/Import.cs
@@ -490,20 +490,20 @@ namespace XenAdmin.Actions.OvfActions
             if (rasds != null && rasds.Length > 0)
             {
                 //The default memory unit is MB (2^20), however, the RASD may contain a different
-                //one with format Bytes*memoryBase^memoryPower (Bytes being a literal string)
+                //one with format byte*memoryBase^memoryPower (byte being a literal string)
 
                 double memoryPower = 20.0;
                 double memoryBase = 2.0;
                
                 foreach (RASD_Type rasd in rasds)
                 {
-                    if (rasd.AllocationUnits.Value.ToLower().StartsWith("bytes"))
+                    if (rasd.AllocationUnits.Value.ToLower().StartsWith("byte"))
                     {
                         string[] a1 = rasd.AllocationUnits.Value.Split('*', '^');
                         if (a1.Length == 3)
                         {
-                            memoryBase = Convert.ToDouble(a1[1]);
-                            memoryPower = Convert.ToDouble(a1[2]);
+                            memoryBase = Convert.ToDouble(a1[1].Trim());
+                            memoryPower = Convert.ToDouble(a1[2].Trim());
                         }
                     }
 

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -10608,15 +10608,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Home Server:.
-        /// </summary>
-        public static string CPM_SUMMARY_KEY_HOME_SERVER {
-            get {
-                return ResourceManager.GetString("CPM_SUMMARY_KEY_HOME_SERVER", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Template:.
         /// </summary>
         public static string CPM_SUMMARY_KEY_MIGRATE_TEMPLATE {
@@ -10667,15 +10658,6 @@ namespace XenAdmin {
         public static string CPM_SUMMARY_NETWORK_NOT_FOUND {
             get {
                 return ResourceManager.GetString("CPM_SUMMARY_NETWORK_NOT_FOUND", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unset.
-        /// </summary>
-        public static string CPM_SUMMARY_UNSET {
-            get {
-                return ResourceManager.GetString("CPM_SUMMARY_UNSET", resourceCulture);
             }
         }
         
@@ -17427,6 +17409,15 @@ namespace XenAdmin {
         public static string FINISH_PAGE_STORAGE_FOR_VM {
             get {
                 return ResourceManager.GetString("FINISH_PAGE_STORAGE_FOR_VM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Home server:.
+        /// </summary>
+        public static string FINISH_PAGE_TARGET_FOR_VM {
+            get {
+                return ResourceManager.GetString("FINISH_PAGE_TARGET_FOR_VM", resourceCulture);
             }
         }
         

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -20905,7 +20905,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} vCPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST {
             get {
@@ -20914,7 +20914,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool..
         /// </summary>
         public static string IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL {
             get {
@@ -20977,7 +20977,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} {2} of memory, while the available memory on the server is {1} {2}. You will not be able to start the VM on the selected server..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} of memory, while the available memory on the server is {1}. You will not be able to start the VM on the selected server..
         /// </summary>
         public static string IMPORT_WIZARD_INSUFFICIENT_MEMORY_HOST {
             get {
@@ -20986,7 +20986,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} {2} of memory, while the maximum available memory on the pool is {1} {2}. You will not be able to start the VM on the selected pool..
+        ///   Looks up a localized string similar to The imported appliance requires a minimum of {0} of memory, while the maximum available memory on the pool is {1}. You will not be able to start the VM on the selected pool..
         /// </summary>
         public static string IMPORT_WIZARD_INSUFFICIENT_MEMORY_POOL {
             get {
@@ -26936,7 +26936,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specify the number of virtual CPUs, their topology, and the amount of memory that will be allocated to the new virtual machine. .
+        ///   Looks up a localized string similar to Specify the number of vCPUs, their topology, and the amount of memory that will be allocated to the new virtual machine. .
         /// </summary>
         public static string NEWVMWIZARD_CPUMEMPAGE_RUBRIC {
             get {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -26972,17 +26972,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.
-        ///
-        ///Review these settings, then click Previous if you need to change anything. Otherwise, click Create Now to create the new VM. It may take several minutes to create the new VM..
-        /// </summary>
-        public static string NEWVMWIZARD_FINISHPAGE {
-            get {
-                return ResourceManager.GetString("NEWVMWIZARD_FINISHPAGE", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &amp;Create Now.
         /// </summary>
         public static string NEWVMWIZARD_FINISHPAGE_CREATE {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -11109,24 +11109,6 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CPU and Memory.
-        /// </summary>
-        public static string CPU_AND_MEMORY {
-            get {
-                return ResourceManager.GetString("CPU_AND_MEMORY", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} vCPU(s) &amp; {1} MB RAM.
-        /// </summary>
-        public static string CPU_AND_MEMORY_SUB {
-            get {
-                return ResourceManager.GetString("CPU_AND_MEMORY_SUB", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {0} vCPU(s).
         /// </summary>
         public static string CPU_SUB {

--- a/XenModel/Messages.Designer.cs
+++ b/XenModel/Messages.Designer.cs
@@ -26909,20 +26909,20 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool ({0})..
+        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory available on any server in the pool ({0})..
         /// </summary>
-        public static string NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1 {
+        public static string NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_FREE {
             get {
-                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1", resourceCulture);
+                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_FREE", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory available on any server in the pool ({0})..
+        ///   Looks up a localized string similar to The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool ({0})..
         /// </summary>
-        public static string NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2 {
+        public static string NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_TOTAL {
             get {
-                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2", resourceCulture);
+                return ResourceManager.GetString("NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_TOTAL", resourceCulture);
             }
         }
         
@@ -26981,7 +26981,7 @@ namespace XenAdmin {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have specified {0} vCPUs, but the server you have selected only has {1} physical CPUs. You will not be able to start the VM..
+        ///   Looks up a localized string similar to You have specified {0} vCPUs, but the server has only {1} physical CPUs. You will not be able to start the VM..
         /// </summary>
         public static string NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST {
             get {

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9395,11 +9395,6 @@ When you configure an NFS storage repository, you simply provide the host name o
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST" xml:space="preserve">
     <value>You have specified {0} vCPUs, but the server has only {1} physical CPUs. You will not be able to start the VM.</value>
   </data>
-  <data name="NEWVMWIZARD_FINISHPAGE" xml:space="preserve">
-    <value>All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.
-
-Review these settings, then click Previous if you need to change anything. Otherwise, click Create Now to create the new VM. It may take several minutes to create the new VM.</value>
-  </data>
   <data name="NEWVMWIZARD_FINISHPAGE_CREATE" xml:space="preserve">
     <value>&amp;Create Now</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -3800,9 +3800,6 @@ This action cannot be undone. Are you sure you want to continue?</value>
   <data name="CPM_SUMMARY_KEY_DESTINATION" xml:space="preserve">
     <value>Destination:</value>
   </data>
-  <data name="CPM_SUMMARY_KEY_HOME_SERVER" xml:space="preserve">
-    <value>Home Server:</value>
-  </data>
   <data name="CPM_SUMMARY_KEY_MIGRATE_TEMPLATE" xml:space="preserve">
     <value>Template:</value>
   </data>
@@ -3820,9 +3817,6 @@ This action cannot be undone. Are you sure you want to continue?</value>
   </data>
   <data name="CPM_SUMMARY_NETWORK_NOT_FOUND" xml:space="preserve">
     <value>Network not found</value>
-  </data>
-  <data name="CPM_SUMMARY_UNSET" xml:space="preserve">
-    <value>Unset</value>
   </data>
   <data name="CPM_WIZARD_ALL_ON_SAME_SR_RADIO" xml:space="preserve">
     <value>Pl&amp;ace all virtual disks on the same SR:</value>
@@ -6104,6 +6098,9 @@ Would you like to eject these ISOs before continuing?</value>
   </data>
   <data name="FINISH_PAGE_STORAGE_FOR_VM" xml:space="preserve">
     <value>{0} storage:</value>
+  </data>
+  <data name="FINISH_PAGE_TARGET_FOR_VM" xml:space="preserve">
+    <value>Home server:</value>
   </data>
   <data name="FINISH_PAGE_TEXT" xml:space="preserve">
     <value>Finish</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -7295,10 +7295,10 @@ This might result in failure to migrate VMs to this server during the RPU or to 
     <value>Place &amp;all imported virtual disks on this target SR:</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_HOST" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server.</value>
+    <value>The imported appliance requires a minimum of {0} vCPUs, while the number of physical CPUs in the selected server is {1}. You will not be able to start the appliance on the selected server.</value>
   </data>
   <data name="IMPORT_WIZARD_CPUS_COUNT_MISMATCH_POOL" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} virtual CPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>
+    <value>The imported appliance requires a minimum of {0} vCPUs, while the maximum number of physical CPUs in the pool is {1}. You will not be able to start the appliance on the selected pool.</value>
   </data>
   <data name="IMPORT_WIZARD_DESTINATION_DESTINATION" xml:space="preserve">
     <value>&amp;Import to:</value>
@@ -7319,10 +7319,10 @@ This might result in failure to migrate VMs to this server during the RPU or to 
     <value>Failed to uncompress file {0}. Please see the logs for more information.</value>
   </data>
   <data name="IMPORT_WIZARD_INSUFFICIENT_MEMORY_HOST" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} {2} of memory, while the available memory on the server is {1} {2}. You will not be able to start the VM on the selected server.</value>
+    <value>The imported appliance requires a minimum of {0} of memory, while the available memory on the server is {1}. You will not be able to start the VM on the selected server.</value>
   </data>
   <data name="IMPORT_WIZARD_INSUFFICIENT_MEMORY_POOL" xml:space="preserve">
-    <value>The imported appliance requires a minimum of {0} {2} of memory, while the maximum available memory on the pool is {1} {2}. You will not be able to start the VM on the selected pool.</value>
+    <value>The imported appliance requires a minimum of {0} of memory, while the maximum available memory on the pool is {1}. You will not be able to start the VM on the selected pool.</value>
   </data>
   <data name="IMPORT_WIZARD_NETWORKING_INTRO" xml:space="preserve">
     <value>Map the virtual network interfaces in the VMs you are importing to networks in the destination pool or standalone server.</value>
@@ -9384,7 +9384,7 @@ When you configure an NFS storage repository, you simply provide the host name o
     <value>CPU &amp;&amp; Memory</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_RUBRIC" xml:space="preserve">
-    <value>Specify the number of virtual CPUs, their topology, and the amount of memory that will be allocated to the new virtual machine. </value>
+    <value>Specify the number of vCPUs, their topology, and the amount of memory that will be allocated to the new virtual machine. </value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_TITLE" xml:space="preserve">
     <value>Allocate processor and memory resources</value>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -3971,12 +3971,6 @@ For optimal performance and reliability during VM migration, ensure that the net
   <data name="CPU" xml:space="preserve">
     <value>CPU</value>
   </data>
-  <data name="CPU_AND_MEMORY" xml:space="preserve">
-    <value>CPU and Memory</value>
-  </data>
-  <data name="CPU_AND_MEMORY_SUB" xml:space="preserve">
-    <value>{0} vCPU(s) &amp; {1} MB RAM</value>
-  </data>
   <data name="CPU_SUB" xml:space="preserve">
     <value>{0} vCPU(s)</value>
   </data>

--- a/XenModel/Messages.resx
+++ b/XenModel/Messages.resx
@@ -9374,11 +9374,11 @@ When you configure an NFS storage repository, you simply provide the host name o
   <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYINFO" xml:space="preserve">
     <value>(min = {0}, max = {1})</value>
   </data>
-  <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN1" xml:space="preserve">
-    <value>The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool ({0}).</value>
-  </data>
-  <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN2" xml:space="preserve">
+  <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_FREE" xml:space="preserve">
     <value>The amount of memory allocated to the new VM is greater than the amount of physical memory available on any server in the pool ({0}).</value>
+  </data>
+  <data name="NEWVMWIZARD_CPUMEMPAGE_MEMORYWARN_TOTAL" xml:space="preserve">
+    <value>The amount of memory allocated to the new VM is greater than the amount of physical memory on any server in the pool ({0}).</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_NAME" xml:space="preserve">
     <value>CPU &amp;&amp; Memory</value>
@@ -9399,7 +9399,7 @@ When you configure an NFS storage repository, you simply provide the host name o
     <value>You have specified {0} vCPUs, but none of the pool servers have more than {1} physical CPUs. You will not be able to start the VM.</value>
   </data>
   <data name="NEWVMWIZARD_CPUMEMPAGE_VCPUSWARN_STANDALONE_HOST" xml:space="preserve">
-    <value>You have specified {0} vCPUs, but the server you have selected only has {1} physical CPUs. You will not be able to start the VM.</value>
+    <value>You have specified {0} vCPUs, but the server has only {1} physical CPUs. You will not be able to start the VM.</value>
   </data>
   <data name="NEWVMWIZARD_FINISHPAGE" xml:space="preserve">
     <value>All the necessary information has been collected and the wizard is ready to provision the new virtual machine using the settings shown below.


### PR DESCRIPTION
Here are some corrections and further UI tweaks. The most dramatic of the changes is the removal of the memory spinner from the VM's CPU properties page because I think it just complicates the code and the user experience. The spinner was visible only under certain conditions which I'm not convinced were clear to the user. The user can already edit the memory from the relevant Memory tabPage, which pops up a dedicated dialog (note that this one does not show any warnings when the user sets the memory too high, so there is room for improvement here too). If we want to make the memory visible on the Properties dialog as well, we should probably show a new Memory tab with the same UI as the dialog from the Memory TabPage. In fact we may want to do this and have the Memory tabPage launch the Properties dialog with the Memory page preselected rather than a different dialog. But all this should be done as a completely new PR.